### PR TITLE
Fix playlists not loading when user disables saving search history (#57)

### DIFF
--- a/Model/RecentsModel.swift
+++ b/Model/RecentsModel.swift
@@ -16,7 +16,7 @@ final class RecentsModel: ObservableObject {
         if !saveRecents {
             clear()
 
-            if item.type != .channel {
+            if item.type != .channel && item.type != .playlist {
                 return
             }
         }


### PR DESCRIPTION
As documented in issue #57, when the user has search history disabled, playlists fail to load correctly. This super simple PR aims to fix this issue. 