### PR TITLE
Fix iOS contact label alignment

### DIFF
--- a/Shared/Settings/SettingsView.swift
+++ b/Shared/Settings/SettingsView.swift
@@ -205,7 +205,7 @@ struct SettingsView: View {
                                     .resizable()
                                     .renderingMode(.template)
                                     .frame(maxWidth: 30, maxHeight: 30)
-
+                                    .padding(.trailing, 6)
                                 Text("Discord Server")
                             }
                         }
@@ -216,6 +216,7 @@ struct SettingsView: View {
                                     .resizable()
                                     .renderingMode(.template)
                                     .frame(maxWidth: 30, maxHeight: 30)
+                                    .padding(.trailing, 6)
                                 Text("Matrix Chat")
                             }
                         }


### PR DESCRIPTION
Before and after:
<img src="https://github.com/yattee/yattee/assets/2276355/ebb889f7-4cf2-4bbf-b0c1-cba234a2603c" width="45%"> <img src="https://github.com/yattee/yattee/assets/2276355/9c2ff628-b27f-47f5-89e0-27b37e20c951" width="45%">