### PR TITLE
honour the aspect ratio when resizing

### DIFF
--- a/Shared/Player/VideoPlayerSizeModifier.swift
+++ b/Shared/Player/VideoPlayerSizeModifier.swift
@@ -43,10 +43,10 @@ struct VideoPlayerSizeModifier: ViewModifier {
     }
 
     var usedAspectRatioContentMode: ContentMode {
-        #if os(iOS)
-            fullScreen ? .fill : .fit
+        #if os(tvOS)
+            .fit
         #else
-                .fit
+            fullScreen ? .fill : .fit
         #endif
     }
 

--- a/Shared/Player/VideoPlayerSizeModifier.swift
+++ b/Shared/Player/VideoPlayerSizeModifier.swift
@@ -27,10 +27,7 @@ struct VideoPlayerSizeModifier: ViewModifier {
         content
             .frame(width: geometry.size.width)
             .frame(maxHeight: maxHeight)
-
-        #if !os(macOS)
             .aspectRatio(ratio, contentMode: usedAspectRatioContentMode)
-        #endif
     }
 
     var ratio: CGFloat? { // swiftlint:disable:this no_cgfloat
@@ -49,7 +46,7 @@ struct VideoPlayerSizeModifier: ViewModifier {
         #if os(iOS)
             fullScreen ? .fill : .fit
         #else
-            .fit
+                .fit
         #endif
     }
 

--- a/Shared/Player/VideoPlayerView.swift
+++ b/Shared/Player/VideoPlayerView.swift
@@ -22,7 +22,7 @@ struct VideoPlayerView: View {
     static let defaultAspectRatio = 16 / 9.0
     static var defaultMinimumHeightLeft: Double {
         #if os(macOS)
-            300
+            335
         #else
             200
         #endif
@@ -315,7 +315,7 @@ struct VideoPlayerView: View {
                             .id(player.currentVideo?.cacheKey)
                             .transition(.opacity)
                         } else {
-                            VStack {}
+                            VStack { }
                         }
                     }
                 #endif
@@ -393,7 +393,7 @@ struct VideoPlayerView: View {
                     }
                 #endif
             } else {
-                VStack {}
+                VStack { }
             }
         }
         .onChange(of: fullScreenPlayer) { newValue in
@@ -508,6 +508,6 @@ struct VideoPlayerView_Previews: PreviewProvider {
             return view
         }
 
-        func updateUIView(_: UIView, context _: Context) {}
+        func updateUIView(_: UIView, context _: Context) { }
     }
 #endif

--- a/Shared/Player/VideoPlayerView.swift
+++ b/Shared/Player/VideoPlayerView.swift
@@ -156,7 +156,7 @@ struct VideoPlayerView: View {
         .persistentSystemOverlays(!fullScreenPlayer)
         #endif
         #if os(macOS)
-        .frame(minWidth: 1100, minHeight: 700)
+        .frame(minWidth: playerSidebar != .never ? 1100 : 650, minHeight: 700)
         #endif
     }
 

--- a/Shared/Player/VideoPlayerView.swift
+++ b/Shared/Player/VideoPlayerView.swift
@@ -315,7 +315,7 @@ struct VideoPlayerView: View {
                             .id(player.currentVideo?.cacheKey)
                             .transition(.opacity)
                         } else {
-                            VStack { }
+                            VStack {}
                         }
                     }
                 #endif
@@ -393,7 +393,7 @@ struct VideoPlayerView: View {
                     }
                 #endif
             } else {
-                VStack { }
+                VStack {}
             }
         }
         .onChange(of: fullScreenPlayer) { newValue in
@@ -508,6 +508,6 @@ struct VideoPlayerView_Previews: PreviewProvider {
             return view
         }
 
-        func updateUIView(_: UIView, context _: Context) { }
+        func updateUIView(_: UIView, context _: Context) {}
     }
 #endif


### PR DESCRIPTION
The `defaultMinimumHeightLeft` has been adjusted to make the radio of the video view 16:9 in its initial state. Also on macOS when resizing the window, the aspect ratio of the view now correlates with the video.

New behavior:

![CleanShot 2023-11-21 at 13 35 49](https://github.com/yattee/yattee/assets/2091312/24190e45-df82-448f-bca0-c2af99e66c0d)


Old behavior:

![CleanShot 2023-11-21 at 13 39 34](https://github.com/yattee/yattee/assets/2091312/c0b1f7ff-dde0-43c7-9548-dab2c1132769)

