### PR TITLE
make chapters collapsible

### DIFF
--- a/Shared/Player/Video Details/ChaptersView.swift
+++ b/Shared/Player/Video Details/ChaptersView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 struct ChaptersView: View {
     @ObservedObject private var player = PlayerModel.shared
+    @Binding var expand: Bool
 
     var chapters: [Chapter] {
         player.videoForDisplay?.chapters ?? []
@@ -14,7 +15,7 @@ struct ChaptersView: View {
     }
 
     var body: some View {
-        if !chapters.isEmpty {
+        if expand && !chapters.isEmpty {
             #if os(tvOS)
                 List {
                     Section {
@@ -45,15 +46,22 @@ struct ChaptersView: View {
                     .padding(.horizontal)
                 }
             #endif
-        } else {
-            NoCommentsView(text: "No chapters information available".localized(), systemImage: "xmark.circle.fill")
+        } else if !chapters.isEmpty {
+            Section {
+                ChapterView(chapter: chapters[0])
+                if chapters.count > 1 {
+                    ChapterView(chapter: chapters[1])
+                        .opacity(0.3)
+                }
+            }
+            .padding(.horizontal)
         }
     }
 }
 
 struct ChaptersView_Previews: PreviewProvider {
     static var previews: some View {
-        ChaptersView()
+        ChaptersView(expand: .constant(false))
             .injectFixtureEnvironmentObjects()
     }
 }

--- a/Shared/Player/Video Details/VideoDetails.swift
+++ b/Shared/Player/Video Details/VideoDetails.swift
@@ -169,6 +169,7 @@ struct VideoDetails: View {
     @State private var subscriptionToggleButtonDisabled = false
     @State private var page = DetailsPage.info
     @State private var descriptionExpanded = false
+    @State private var chaptersExpanded = false
 
     @Environment(\.navigationStyle) private var navigationStyle
     #if os(iOS)
@@ -314,10 +315,9 @@ struct VideoDetails: View {
                                 if player.videoBeingOpened.isNil {
                                     if showChapters,
                                        !video.isLocal,
-                                       !video.chapters.isEmpty
-                                    {
+                                       !video.chapters.isEmpty {
                                         Section(header: chaptersHeader) {
-                                            ChaptersView()
+                                            ChaptersView(expand: $chaptersExpanded)
                                         }
                                     }
 
@@ -328,8 +328,7 @@ struct VideoDetails: View {
 
                                     if showRelated,
                                        !sidebarQueue,
-                                       !(player.videoForDisplay?.related.isEmpty ?? true)
-                                    {
+                                       !(player.videoForDisplay?.related.isEmpty ?? true) {
                                         RelatedView()
                                             .padding(.horizontal)
                                             .padding(.top, 20)
@@ -387,8 +386,7 @@ struct VideoDetails: View {
             if showScrollToTopInComments,
                page == .comments,
                comments.loaded,
-               comments.all.count > 3
-            {
+               comments.all.count > 3 {
                 Button {
                     withAnimation {
                         proxy.scrollTo(Self.pageMenuID)
@@ -409,10 +407,10 @@ struct VideoDetails: View {
     var descriptionHeader: some View {
         HStack {
             Text("Description".localized())
-
-            if !expandVideoDescription, !descriptionExpanded {
-                Spacer()
-                Image(systemName: "arrow.up.and.down")
+            Spacer()
+            Button { descriptionExpanded.toggle()
+            } label: {
+                Image(systemName: descriptionExpanded ? "chevron.up" : "chevron.down")
                     .imageScale(.small)
             }
         }
@@ -422,10 +420,17 @@ struct VideoDetails: View {
     }
 
     var chaptersHeader: some View {
-        Text("Chapters".localized())
-            .padding(.horizontal)
-            .font(.caption)
-            .foregroundColor(.secondary)
+        HStack {
+            Text("Chapters".localized())
+            Spacer()
+            Button(action: { chaptersExpanded.toggle() }) {
+                Image(systemName: chaptersExpanded ? "chevron.up" : "chevron.down")
+                    .imageScale(.small)
+            }
+        }
+        .padding(.horizontal)
+        .font(.caption)
+        .foregroundColor(.secondary)
     }
 }
 

--- a/Shared/Settings/PlayerSettings.swift
+++ b/Shared/Settings/PlayerSettings.swift
@@ -262,7 +262,7 @@ struct PlayerSettings: View {
         }
 
         private var showChaptersToggle: some View {
-            Toggle("Chapters", isOn: $showChapters)
+            Toggle("Chapters (if available)", isOn: $showChapters)
         }
 
         private var showRelatedToggle: some View {


### PR DESCRIPTION
Chapters are now collapsible by default only the first two chapters are shown. The second will be shown opaque to indicate more chapters.

on macOS:

![CleanShot 2023-11-21 at 15 06 22](https://github.com/yattee/yattee/assets/2091312/6d49b7b1-58f7-4c6d-a1c4-592a282f7b7a)

on iOS:

![CleanShot 2023-11-21 at 15 24 45](https://github.com/yattee/yattee/assets/2091312/748ec835-e7be-41db-a3a7-686236e8f59d)
