### PR TITLE
make chapters collapsible and highlight current chapter

### DIFF
--- a/Model/Player/Backends/AVPlayerBackend.swift
+++ b/Model/Player/Backends/AVPlayerBackend.swift
@@ -116,6 +116,10 @@ final class AVPlayerBackend: PlayerBackend {
         #endif
     }
 
+    deinit {
+        NotificationCenter.default.removeObserver(self, name: .getTimeUpdatesNotification, object: self.currentTime)
+    }
+
     func bestPlayable(_ streams: [Stream], maxResolution: ResolutionSetting) -> Stream? {
         let sortedByResolution = streams
             .filter { ($0.kind == .adaptive || $0.kind == .stream) && $0.resolution <= maxResolution.value }
@@ -596,6 +600,8 @@ final class AVPlayerBackend: PlayerBackend {
             if self.controlsUpdates {
                 self.updateControls()
             }
+
+            NotificationCenter.default.post(name: .getTimeUpdatesNotification, object: self.currentTime)
         }
     }
 

--- a/Model/Player/Backends/AVPlayerBackend.swift
+++ b/Model/Player/Backends/AVPlayerBackend.swift
@@ -116,10 +116,6 @@ final class AVPlayerBackend: PlayerBackend {
         #endif
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self, name: .getTimeUpdatesNotification, object: self.currentTime)
-    }
-
     func bestPlayable(_ streams: [Stream], maxResolution: ResolutionSetting) -> Stream? {
         let sortedByResolution = streams
             .filter { ($0.kind == .adaptive || $0.kind == .stream) && $0.resolution <= maxResolution.value }
@@ -601,7 +597,7 @@ final class AVPlayerBackend: PlayerBackend {
                 self.updateControls()
             }
 
-            NotificationCenter.default.post(name: .getTimeUpdatesNotification, object: self.currentTime)
+            self.model.updateTime(self.currentTime!)
         }
     }
 

--- a/Model/Player/Backends/MPVBackend.swift
+++ b/Model/Player/Backends/MPVBackend.swift
@@ -182,6 +182,7 @@ final class MPVBackend: PlayerBackend {
     }
 
     init() {
+        // swiftlint:disable shorthand_optional_binding
         clientTimer = .init(interval: .seconds(Self.timeUpdateInterval), mode: .infinite) { [weak self] _ in
             guard let self = self, self.model.activeBackend == .mpv else {
                 return
@@ -195,10 +196,7 @@ final class MPVBackend: PlayerBackend {
             }
             self.updateNetworkState()
         }
-    }
-
-    deinit {
-        NotificationCenter.default.removeObserver(self, name: .getTimeUpdatesNotification, object: self.currentTime)
+        // swiftlint:enable shorthand_optional_binding
     }
 
     typealias AreInIncreasingOrder = (Stream, Stream) -> Bool
@@ -443,7 +441,7 @@ final class MPVBackend: PlayerBackend {
             self.model.updateWatch(time: self.currentTime)
         }
 
-        NotificationCenter.default.post(name: .getTimeUpdatesNotification, object: self.currentTime)
+        self.model.updateTime(self.currentTime!)
     }
 
     private func stopClientUpdates() {

--- a/Model/Player/Backends/MPVBackend.swift
+++ b/Model/Player/Backends/MPVBackend.swift
@@ -191,6 +191,10 @@ final class MPVBackend: PlayerBackend {
         }
     }
 
+    deinit {
+        NotificationCenter.default.removeObserver(self, name: .getTimeUpdatesNotification, object: self.currentTime)
+    }
+
     typealias AreInIncreasingOrder = (Stream, Stream) -> Bool
 
     func bestPlayable(_ streams: [Stream], maxResolution: ResolutionSetting) -> Stream? {
@@ -432,6 +436,8 @@ final class MPVBackend: PlayerBackend {
         timeObserverThrottle.execute {
             self.model.updateWatch(time: self.currentTime)
         }
+
+        NotificationCenter.default.post(name: .getTimeUpdatesNotification, object: self.currentTime)
     }
 
     private func stopClientUpdates() {
@@ -617,4 +623,8 @@ final class MPVBackend: PlayerBackend {
             logger.info("MPV backend received unhandled property: \(name)")
         }
     }
+}
+
+extension Notification.Name {
+    static let getTimeUpdatesNotification = Notification.Name("getTimeUpdatesNotification")
 }

--- a/Model/Player/Backends/MPVBackend.swift
+++ b/Model/Player/Backends/MPVBackend.swift
@@ -183,11 +183,17 @@ final class MPVBackend: PlayerBackend {
 
     init() {
         clientTimer = .init(interval: .seconds(Self.timeUpdateInterval), mode: .infinite) { [weak self] _ in
-            self?.getTimeUpdates()
+            guard let self = self, self.model.activeBackend == .mpv else {
+                return
+            }
+            self.getTimeUpdates()
         }
 
         networkStateTimer = .init(interval: .seconds(Self.networkStateUpdateInterval), mode: .infinite) { [weak self] _ in
-            self?.updateNetworkState()
+            guard let self = self, self.model.activeBackend == .mpv else {
+                return
+            }
+            self.updateNetworkState()
         }
     }
 
@@ -623,8 +629,4 @@ final class MPVBackend: PlayerBackend {
             logger.info("MPV backend received unhandled property: \(name)")
         }
     }
-}
-
-extension Notification.Name {
-    static let getTimeUpdatesNotification = Notification.Name("getTimeUpdatesNotification")
 }

--- a/Model/Player/Backends/PlayerBackend.swift
+++ b/Model/Player/Backends/PlayerBackend.swift
@@ -154,3 +154,7 @@ extension PlayerBackend {
         }
     }
 }
+
+extension Notification.Name {
+    static let getTimeUpdatesNotification = Notification.Name("getTimeUpdatesNotification")
+}

--- a/Model/Player/Backends/PlayerBackend.swift
+++ b/Model/Player/Backends/PlayerBackend.swift
@@ -154,7 +154,3 @@ extension PlayerBackend {
         }
     }
 }
-
-extension Notification.Name {
-    static let getTimeUpdatesNotification = Notification.Name("getTimeUpdatesNotification")
-}

--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -131,6 +131,9 @@ final class PlayerModel: ObservableObject {
         @Default(.rotateToLandscapeOnEnterFullScreen) private var rotateToLandscapeOnEnterFullScreen
     #endif
 
+    @Published var playedChapters: [Int] = []
+    @Published var currentChapterIndex: Int?
+
     var accounts: AccountsModel { .shared }
     var comments: CommentsModel { .shared }
     var controls: PlayerControlsModel { .shared }

--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -131,8 +131,7 @@ final class PlayerModel: ObservableObject {
         @Default(.rotateToLandscapeOnEnterFullScreen) private var rotateToLandscapeOnEnterFullScreen
     #endif
 
-    @Published var playedChapters: [Int] = []
-    @Published var currentChapterIndex: Int?
+    @Published var currentChapter: Int?
 
     var accounts: AccountsModel { .shared }
     var comments: CommentsModel { .shared }

--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -131,7 +131,7 @@ final class PlayerModel: ObservableObject {
         @Default(.rotateToLandscapeOnEnterFullScreen) private var rotateToLandscapeOnEnterFullScreen
     #endif
 
-    @Published var currentChapter: Int?
+    @Published var currentChapterIndex: Int?
 
     var accounts: AccountsModel { .shared }
     var comments: CommentsModel { .shared }
@@ -1113,5 +1113,37 @@ final class PlayerModel: ObservableObject {
 
         onPlayStream.forEach { $0(stream) }
         onPlayStream.removeAll()
+    }
+
+    func updateTime(_ cmTime: CMTime) {
+        let time = CMTimeGetSeconds(cmTime)
+        let newChapterIndex = chapterForTime(time)
+        if currentChapterIndex != newChapterIndex {
+            DispatchQueue.main.async {
+                self.currentChapterIndex = newChapterIndex
+            }
+        }
+    }
+
+    private func chapterForTime(_ time: Double) -> Int? {
+        guard let chapters = self.videoForDisplay?.chapters else {
+            return nil
+        }
+
+        for (index, chapter) in chapters.enumerated() {
+            let nextChapterStartTime = index < (chapters.count - 1) ? chapters[index + 1].start : nil
+
+            if let nextChapterStart = nextChapterStartTime {
+                if time >= chapter.start, time < nextChapterStart {
+                    return index
+                }
+            } else {
+                if time >= chapter.start {
+                    return index
+                }
+            }
+        }
+
+        return nil
     }
 }

--- a/Shared/Defaults.swift
+++ b/Shared/Defaults.swift
@@ -265,6 +265,7 @@ extension Defaults.Keys {
     static let hideWatched = Key<Bool>("hideWatched", default: false)
     static let showInspector = Key<ShowInspectorSetting>("showInspector", default: .onlyLocal)
     static let showChapters = Key<Bool>("showChapters", default: true)
+    static let expandChapters = Key<Bool>("expandChapters", default: true)
     static let showRelated = Key<Bool>("showRelated", default: true)
     static let widgetsSettings = Key<[WidgetSettings]>("widgetsSettings", default: [])
 }

--- a/Shared/Player/Video Details/ChapterView.swift
+++ b/Shared/Player/Video Details/ChapterView.swift
@@ -6,13 +6,12 @@ import SwiftUI
 #if !os(tvOS)
     struct ChapterView: View {
         var chapter: Chapter
-        var nextChapterStart: Double?
 
         var chapterIndex: Int
         @ObservedObject private var player = PlayerModel.shared
 
         var isCurrentChapter: Bool {
-            player.currentChapter == chapterIndex
+            player.currentChapterIndex == chapterIndex
         }
 
         var body: some View {
@@ -31,7 +30,7 @@ import SwiftUI
                     .receive(on: DispatchQueue.main)
             ) { notification in
                 if let cmTime = notification.object as? CMTime {
-                    self.handleTimeUpdate(cmTime)
+                    player.updateTime(cmTime)
                 }
             }
         }
@@ -73,13 +72,6 @@ import SwiftUI
 
         static var thumbnailHeight: Double {
             thumbnailWidth / 1.7777
-        }
-
-        private func handleTimeUpdate(_ cmTime: CMTime) {
-            let time = CMTimeGetSeconds(cmTime)
-            if time >= chapter.start, nextChapterStart == nil || time < nextChapterStart! {
-                player.currentChapter = chapterIndex
-            }
         }
     }
 
@@ -144,7 +136,7 @@ struct ChapterView_Preview: PreviewProvider {
             ChapterViewTVOS(chapter: .init(title: "Chapter", start: 30))
                 .injectFixtureEnvironmentObjects()
         #else
-            ChapterView(chapter: .init(title: "Chapter", start: 30), nextChapterStart: nil, chapterIndex: 0)
+            ChapterView(chapter: .init(title: "Chapter", start: 30), chapterIndex: 0)
                 .injectFixtureEnvironmentObjects()
         #endif
     }

--- a/Shared/Player/Video Details/ChapterView.swift
+++ b/Shared/Player/Video Details/ChapterView.swift
@@ -3,65 +3,44 @@ import Foundation
 import SDWebImageSwiftUI
 import SwiftUI
 
-struct ChapterView: View {
-    var chapter: Chapter
-    var nextChapterStart: Double?
+#if !os(tvOS)
+    struct ChapterView: View {
+        var chapter: Chapter
+        var nextChapterStart: Double?
 
-    var chapterIndex: Int
-    @ObservedObject private var player = PlayerModel.shared
+        var chapterIndex: Int
+        @ObservedObject private var player = PlayerModel.shared
 
-    var isCurrentChapter: Bool {
-        player.currentChapterIndex == chapterIndex
-    }
+        var isCurrentChapter: Bool {
+            player.currentChapterIndex == chapterIndex
+        }
 
-    var hasBeenPlayed: Bool {
-        player.playedChapters.contains(chapterIndex)
-    }
+        var hasBeenPlayed: Bool {
+            player.playedChapters.contains(chapterIndex)
+        }
 
-    var body: some View {
-        Button(action: {
-            player.backend.seek(to: chapter.start, seekType: .userInteracted)
-        }) {
-            Group {
-                #if os(tvOS)
-                    horizontalChapter
-                #else
+        var body: some View {
+            Button(action: {
+                player.backend.seek(to: chapter.start, seekType: .userInteracted)
+            }) {
+                Group {
                     verticalChapter
-                #endif
+                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .onReceive(PlayerTimeModel.shared.$currentTime) { cmTime in
-            let time = CMTimeGetSeconds(cmTime)
-            if time >= self.chapter.start, self.nextChapterStart == nil || time < self.nextChapterStart! {
-                player.currentChapterIndex = self.chapterIndex
-                if !player.playedChapters.contains(self.chapterIndex) {
-                    player.playedChapters.append(self.chapterIndex)
+            .buttonStyle(.plain)
+
+            .onReceive(PlayerTimeModel.shared.$currentTime) { cmTime in
+                let time = CMTimeGetSeconds(cmTime)
+                if time >= self.chapter.start, self.nextChapterStart == nil || time < self.nextChapterStart! {
+                    player.currentChapterIndex = self.chapterIndex
+                    if !player.playedChapters.contains(self.chapterIndex) {
+                        player.playedChapters.append(self.chapterIndex)
+                    }
                 }
             }
         }
-    }
 
-    #if os(tvOS)
-
-        var horizontalChapter: some View {
-            HStack(spacing: 12) {
-                if !chapter.image.isNil {
-                    smallImage(chapter)
-                }
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(chapter.title)
-                        .font(.headline)
-                    Text(chapter.start.formattedAsPlaybackTime(allowZero: true) ?? "")
-                        .font(.system(.subheadline).monospacedDigit())
-                        .foregroundColor(.secondary)
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-    #else
         var verticalChapter: some View {
             VStack(spacing: 12) {
                 if !chapter.image.isNil {
@@ -80,35 +59,91 @@ struct ChapterView: View {
                 .frame(maxWidth: !chapter.image.isNil ? Self.thumbnailWidth : nil, alignment: .leading)
             }
         }
-    #endif
 
-    @ViewBuilder func smallImage(_ chapter: Chapter) -> some View {
-        WebImage(url: chapter.image, options: [.lowPriority])
-            .resizable()
-            .placeholder {
-                ProgressView()
+        @ViewBuilder func smallImage(_ chapter: Chapter) -> some View {
+            WebImage(url: chapter.image, options: [.lowPriority])
+                .resizable()
+                .placeholder {
+                    ProgressView()
+                }
+                .indicator(.activity)
+                .frame(width: Self.thumbnailWidth, height: Self.thumbnailHeight)
+
+                .mask(RoundedRectangle(cornerRadius: 6))
+        }
+
+        static var thumbnailWidth: Double {
+            250
+        }
+
+        static var thumbnailHeight: Double {
+            thumbnailWidth / 1.7777
+        }
+    }
+
+#else
+    struct ChapterViewTVOS: View {
+        var chapter: Chapter
+        var player = PlayerModel.shared
+
+        var body: some View {
+            Button {
+                player.backend.seek(to: chapter.start, seekType: .userInteracted)
+            } label: {
+                Group {
+                    horizontalChapter
+                }
+                .contentShape(Rectangle())
             }
-            .indicator(.activity)
-            .frame(width: Self.thumbnailWidth, height: Self.thumbnailHeight)
-        #if os(tvOS)
-            .mask(RoundedRectangle(cornerRadius: 12))
-        #else
-            .mask(RoundedRectangle(cornerRadius: 6))
-        #endif
-    }
+            .buttonStyle(.plain)
+        }
 
-    static var thumbnailWidth: Double {
-        250
-    }
+        var horizontalChapter: some View {
+            HStack(spacing: 12) {
+                if !chapter.image.isNil {
+                    smallImage(chapter)
+                }
 
-    static var thumbnailHeight: Double {
-        thumbnailWidth / 1.7777
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(chapter.title)
+                        .font(.headline)
+                    Text(chapter.start.formattedAsPlaybackTime(allowZero: true) ?? "")
+                        .font(.system(.subheadline).monospacedDigit())
+                        .foregroundColor(.secondary)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+
+        @ViewBuilder func smallImage(_ chapter: Chapter) -> some View {
+            WebImage(url: chapter.image, options: [.lowPriority])
+                .resizable()
+                .placeholder {
+                    ProgressView()
+                }
+                .indicator(.activity)
+                .frame(width: Self.thumbnailWidth, height: Self.thumbnailHeight)
+                .mask(RoundedRectangle(cornerRadius: 12))
+        }
+
+        static var thumbnailWidth: Double {
+            250
+        }
+
+        static var thumbnailHeight: Double {
+            thumbnailWidth / 1.7777
+        }
     }
-}
+#endif
 
 struct ChapterView_Preview: PreviewProvider {
     static var previews: some View {
-        ChapterView(chapter: .init(title: "Chapter", start: 30), chapterIndex: 0)
-            .injectFixtureEnvironmentObjects()
+        #if os(tvOS)
+            ChapterViewTVOS(chapter: .init(title: "Chapter", start: 30))
+                .injectFixtureEnvironmentObjects()
+        #else
+            ChapterView(chapter: .init(title: "Chapter", start: 30), nextChapterStart: nil, chapterIndex: 0)
+                .injectFixtureEnvironmentObjects()
+        #endif
     }
 }

--- a/Shared/Player/Video Details/ChapterView.swift
+++ b/Shared/Player/Video Details/ChapterView.swift
@@ -49,14 +49,14 @@ struct ChapterView: View {
                 }
                 VStack(alignment: .leading, spacing: 4) {
                     Text(chapter.title)
-                        .lineLimit(2)
+                        .lineLimit(3)
                         .multilineTextAlignment(.leading)
                         .font(.headline)
                     Text(chapter.start.formattedAsPlaybackTime(allowZero: true) ?? "")
                         .font(.system(.subheadline).monospacedDigit())
                         .foregroundColor(.secondary)
                 }
-                .frame(maxWidth: Self.thumbnailWidth, alignment: .leading)
+                .frame(maxWidth: !chapter.image.isNil ? Self.thumbnailWidth : nil, alignment: .leading)
             }
         }
     #endif

--- a/Shared/Player/Video Details/ChapterView.swift
+++ b/Shared/Player/Video Details/ChapterView.swift
@@ -1,4 +1,3 @@
-import CoreMedia
 import Foundation
 import SDWebImageSwiftUI
 import SwiftUI
@@ -24,15 +23,6 @@ import SwiftUI
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .onReceive(
-                NotificationCenter.default
-                    .publisher(for: .getTimeUpdatesNotification)
-                    .receive(on: DispatchQueue.main)
-            ) { notification in
-                if let cmTime = notification.object as? CMTime {
-                    player.updateTime(cmTime)
-                }
-            }
         }
 
         var verticalChapter: some View {

--- a/Shared/Player/Video Details/ChapterView.swift
+++ b/Shared/Player/Video Details/ChapterView.swift
@@ -29,7 +29,6 @@ import SwiftUI
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-
             .onReceive(PlayerTimeModel.shared.$currentTime) { cmTime in
                 let time = CMTimeGetSeconds(cmTime)
                 if time >= self.chapter.start, self.nextChapterStart == nil || time < self.nextChapterStart! {
@@ -51,7 +50,7 @@ import SwiftUI
                         .lineLimit(3)
                         .multilineTextAlignment(.leading)
                         .font(.headline)
-                        .foregroundColor(isCurrentChapter ? .detailBadgeOutstandingStyleBackground : .primary)
+                        .foregroundColor(isCurrentChapter ? .appRed : .primary)
                     Text(chapter.start.formattedAsPlaybackTime(allowZero: true) ?? "")
                         .font(.system(.subheadline).monospacedDigit())
                         .foregroundColor(.secondary)

--- a/Shared/Player/Video Details/ChapterView.swift
+++ b/Shared/Player/Video Details/ChapterView.swift
@@ -12,11 +12,7 @@ import SwiftUI
         @ObservedObject private var player = PlayerModel.shared
 
         var isCurrentChapter: Bool {
-            player.currentChapterIndex == chapterIndex
-        }
-
-        var hasBeenPlayed: Bool {
-            player.playedChapters.contains(chapterIndex)
+            player.currentChapter == chapterIndex
         }
 
         var body: some View {
@@ -35,6 +31,7 @@ import SwiftUI
             .buttonStyle(.plain)
             .onReceive(PlayerTimeModel.shared.$currentTime) { cmTime in
                 self.handleTimeUpdate(cmTime)
+                print("currentChapterIndex:", player.currentChapter ?? 0)
             }
         }
 
@@ -80,10 +77,7 @@ import SwiftUI
         private func handleTimeUpdate(_ cmTime: CMTime) {
             let time = CMTimeGetSeconds(cmTime)
             if time >= chapter.start, nextChapterStart == nil || time < nextChapterStart! {
-                player.currentChapterIndex = chapterIndex
-                if !player.playedChapters.contains(chapterIndex) {
-                    player.playedChapters.append(chapterIndex)
-                }
+                player.currentChapter = chapterIndex
             }
         }
     }

--- a/Shared/Player/Video Details/ChaptersView.swift
+++ b/Shared/Player/Video Details/ChaptersView.swift
@@ -30,8 +30,10 @@ struct ChaptersView: View {
                 #else
                     ScrollView(.horizontal) {
                         LazyHStack(spacing: 20) {
-                            ForEach(chapters) { chapter in
-                                ChapterView(chapter: chapter)
+                            ForEach(Array(chapters.indices), id: \.self) { index in
+                                let chapter = chapters[index]
+                                let nextChapterStart: Double? = index < chapters.count - 1 ? chapters[index + 1].start : nil
+                                ChapterView(chapter: chapter, nextChapterStart: nextChapterStart, chapterIndex: index)
                             }
                         }
                         .padding(.horizontal, 15)
@@ -39,8 +41,10 @@ struct ChaptersView: View {
                 #endif
             } else if expand {
                 Section {
-                    ForEach(chapters) { chapter in
-                        ChapterView(chapter: chapter)
+                    ForEach(Array(chapters.indices), id: \.self) { index in
+                        let chapter = chapters[index]
+                        let nextChapterStart: Double? = index < chapters.count - 1 ? chapters[index + 1].start : nil
+                        ChapterView(chapter: chapter, nextChapterStart: nextChapterStart, chapterIndex: index)
                     }
                 }
                 .padding(.horizontal)
@@ -60,8 +64,10 @@ struct ChaptersView: View {
 
     var contents: some View {
         Section {
-            ForEach(chapters.prefix(3).indices, id: \.self) { index in
-                ChapterView(chapter: chapters[index])
+            ForEach(Array(chapters.prefix(3).indices), id: \.self) { index in
+                let chapter = chapters[index]
+                let nextChapterStart: Double? = index < chapters.count - 1 ? chapters[index + 1].start : nil
+                ChapterView(chapter: chapter, nextChapterStart: nextChapterStart, chapterIndex: index)
                     .allowsHitTesting(expand)
                     .opacity(index == 0 ? 1.0 : 0.3)
             }

--- a/Shared/Player/Video Details/ChaptersView.swift
+++ b/Shared/Player/Video Details/ChaptersView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 struct ChaptersView: View {
     @ObservedObject private var player = PlayerModel.shared
+    @Binding var expand: Bool
 
     var chapters: [Chapter] {
         player.videoForDisplay?.chapters ?? []
@@ -14,7 +15,7 @@ struct ChaptersView: View {
     }
 
     var body: some View {
-        if !chapters.isEmpty {
+        if expand && !chapters.isEmpty {
             #if os(tvOS)
                 List {
                     Section {
@@ -45,15 +46,22 @@ struct ChaptersView: View {
                     .padding(.horizontal)
                 }
             #endif
-        } else {
-            NoCommentsView(text: "No chapters information available".localized(), systemImage: "xmark.circle.fill")
+        } else if !chapters.isEmpty {
+            Section {
+                ChapterView(chapter: chapters[0])
+                if chapters.count > 1 {
+                    ChapterView(chapter: chapters[1])
+                        .opacity(0.3)
+                }
+            }
+            .padding(.horizontal)
         }
     }
 }
 
 struct ChaptersView_Previews: PreviewProvider {
     static var previews: some View {
-        ChaptersView()
+        ChaptersView(expand: .constant(false))
             .injectFixtureEnvironmentObjects()
     }
 }

--- a/Shared/Player/Video Details/ChaptersView.swift
+++ b/Shared/Player/Video Details/ChaptersView.swift
@@ -47,15 +47,27 @@ struct ChaptersView: View {
                 }
             #endif
         } else if !chapters.isEmpty {
-            Section {
-                ChapterView(chapter: chapters[0])
-                if chapters.count > 1 {
-                    ChapterView(chapter: chapters[1])
-                        .opacity(0.3)
+            #if os(iOS)
+                Button(action: {
+                    self.expand.toggle() // Use your expanding logic here
+                }) {
+                    contents
                 }
-            }
-            .padding(.horizontal)
+            #else
+                contents
+            #endif
         }
+    }
+
+    var contents: some View {
+        Section {
+            ForEach(chapters.prefix(3).indices, id: \.self) { index in
+                ChapterView(chapter: chapters[index])
+                    .allowsHitTesting(expand)
+                    .opacity(index == 0 ? 1.0 : 0.3)
+            }
+        }
+        .padding(.horizontal)
     }
 }
 

--- a/Shared/Player/Video Details/ChaptersView.swift
+++ b/Shared/Player/Video Details/ChaptersView.swift
@@ -37,7 +37,6 @@ struct ChaptersView: View {
                             }
                             .padding(.horizontal, 15)
                         }
-                        .frame(minHeight: ChapterView.thumbnailHeight + 100)
                     } else {
                         contents
                     }

--- a/Shared/Player/Video Details/ChaptersView.swift
+++ b/Shared/Player/Video Details/ChaptersView.swift
@@ -21,7 +21,7 @@ struct ChaptersView: View {
                     List {
                         Section {
                             ForEach(chapters) { chapter in
-                                ChapterView(chapter: chapter)
+                                ChapterViewTVOS(chapter: chapter)
                             }
                         }
                         .listRowBackground(Color.clear)
@@ -29,51 +29,53 @@ struct ChaptersView: View {
                     .listStyle(.plain)
                 #else
                     ScrollView(.horizontal) {
-                        LazyHStack(spacing: 20) {
-                            ForEach(Array(chapters.indices), id: \.self) { index in
-                                let chapter = chapters[index]
-                                let nextChapterStart: Double? = index < chapters.count - 1 ? chapters[index + 1].start : nil
-                                ChapterView(chapter: chapter, nextChapterStart: nextChapterStart, chapterIndex: index)
-                            }
-                        }
-                        .padding(.horizontal, 15)
+                        LazyHStack(spacing: 20) { chapterViews(for: chapters.prefix(3), opacity: 1.0) }.padding(.horizontal, 15)
                     }
                 #endif
             } else if expand {
-                Section {
-                    ForEach(Array(chapters.indices), id: \.self) { index in
-                        let chapter = chapters[index]
-                        let nextChapterStart: Double? = index < chapters.count - 1 ? chapters[index + 1].start : nil
-                        ChapterView(chapter: chapter, nextChapterStart: nextChapterStart, chapterIndex: index)
+                #if os(tvOS)
+                    Section {
+                        ForEach(chapters) { chapter in
+                            ChapterViewTVOS(chapter: chapter)
+                        }
                     }
-                }
-                .padding(.horizontal)
+                #else
+                    Section { chapterViews(for: chapters[...], opacity: 1.0) }.padding(.horizontal)
+                #endif
             } else {
                 #if os(iOS)
                     Button(action: {
                         self.expand.toggle()
                     }) {
-                        contents
+                        Section {
+                            chapterViews(for: chapters.prefix(3), opacity: 0.3)
+                        }.padding(.horizontal)
                     }
+                #elseif os(macOS)
+                    Section {
+                        chapterViews(for: chapters.prefix(3), opacity: 0.3)
+                    }.padding(.horizontal)
                 #else
-                    contents
+                    Section {
+                        ForEach(chapters) { chapter in
+                            ChapterViewTVOS(chapter: chapter)
+                        }
+                    }
                 #endif
             }
         }
     }
 
-    var contents: some View {
-        Section {
-            ForEach(Array(chapters.prefix(3).indices), id: \.self) { index in
-                let chapter = chapters[index]
-                let nextChapterStart: Double? = index < chapters.count - 1 ? chapters[index + 1].start : nil
+    #if !os(tvOS)
+        private func chapterViews(for chaptersToShow: ArraySlice<Chapter>, opacity: Double = 1.0) -> some View {
+            ForEach(Array(chaptersToShow.indices), id: \.self) { index in
+                let chapter = chaptersToShow[index]
+                let nextChapterStart: Double? = index < chaptersToShow.count - 1 ? chaptersToShow[index + 1].start : nil
                 ChapterView(chapter: chapter, nextChapterStart: nextChapterStart, chapterIndex: index)
-                    .allowsHitTesting(expand)
-                    .opacity(index == 0 ? 1.0 : 0.3)
+                    .opacity(index == 0 ? 1.0 : opacity)
             }
         }
-        .padding(.horizontal)
-    }
+    #endif
 }
 
 struct ChaptersView_Previews: PreviewProvider {

--- a/Shared/Player/Video Details/ChaptersView.swift
+++ b/Shared/Player/Video Details/ChaptersView.swift
@@ -16,7 +16,7 @@ struct ChaptersView: View {
 
     var body: some View {
         if !chapters.isEmpty {
-            if expand || chaptersHaveImages {
+            if chaptersHaveImages {
                 #if os(tvOS)
                     List {
                         Section {
@@ -28,19 +28,22 @@ struct ChaptersView: View {
                     }
                     .listStyle(.plain)
                 #else
-                    if chaptersHaveImages {
-                        ScrollView(.horizontal) {
-                            LazyHStack(spacing: 20) {
-                                ForEach(chapters) { chapter in
-                                    ChapterView(chapter: chapter)
-                                }
+                    ScrollView(.horizontal) {
+                        LazyHStack(spacing: 20) {
+                            ForEach(chapters) { chapter in
+                                ChapterView(chapter: chapter)
                             }
-                            .padding(.horizontal, 15)
                         }
-                    } else {
-                        contents
+                        .padding(.horizontal, 15)
                     }
                 #endif
+            } else if expand {
+                Section {
+                    ForEach(chapters) { chapter in
+                        ChapterView(chapter: chapter)
+                    }
+                }
+                .padding(.horizontal)
             } else {
                 #if os(iOS)
                     Button(action: {

--- a/Shared/Player/Video Details/ChaptersView.swift
+++ b/Shared/Player/Video Details/ChaptersView.swift
@@ -70,8 +70,7 @@ struct ChaptersView: View {
         private func chapterViews(for chaptersToShow: ArraySlice<Chapter>, opacity: Double = 1.0, clickable: Bool = true) -> some View {
             ForEach(Array(chaptersToShow.indices), id: \.self) { index in
                 let chapter = chaptersToShow[index]
-                let nextChapterStart: Double? = index < chaptersToShow.count - 1 ? chaptersToShow[index + 1].start : nil
-                ChapterView(chapter: chapter, nextChapterStart: nextChapterStart, chapterIndex: index)
+                ChapterView(chapter: chapter, chapterIndex: index)
                     .opacity(index == 0 ? 1.0 : opacity)
                     .allowsHitTesting(clickable)
             }

--- a/Shared/Player/Video Details/ChaptersView.swift
+++ b/Shared/Player/Video Details/ChaptersView.swift
@@ -15,47 +15,44 @@ struct ChaptersView: View {
     }
 
     var body: some View {
-        if expand && !chapters.isEmpty {
-            #if os(tvOS)
-                List {
-                    Section {
-                        ForEach(chapters) { chapter in
-                            ChapterView(chapter: chapter)
-                        }
-                    }
-                    .listRowBackground(Color.clear)
-                }
-                .listStyle(.plain)
-            #else
-                if chaptersHaveImages {
-                    ScrollView(.horizontal) {
-                        LazyHStack(spacing: 20) {
+        if !chapters.isEmpty {
+            if expand || chaptersHaveImages {
+                #if os(tvOS)
+                    List {
+                        Section {
                             ForEach(chapters) { chapter in
                                 ChapterView(chapter: chapter)
                             }
                         }
-                        .padding(.horizontal, 15)
+                        .listRowBackground(Color.clear)
                     }
-                    .frame(minHeight: ChapterView.thumbnailHeight + 100)
-                } else {
-                    Section {
-                        ForEach(chapters) { chapter in
-                            ChapterView(chapter: chapter)
+                    .listStyle(.plain)
+                #else
+                    if chaptersHaveImages {
+                        ScrollView(.horizontal) {
+                            LazyHStack(spacing: 20) {
+                                ForEach(chapters) { chapter in
+                                    ChapterView(chapter: chapter)
+                                }
+                            }
+                            .padding(.horizontal, 15)
                         }
+                        .frame(minHeight: ChapterView.thumbnailHeight + 100)
+                    } else {
+                        contents
                     }
-                    .padding(.horizontal)
-                }
-            #endif
-        } else if !chapters.isEmpty {
-            #if os(iOS)
-                Button(action: {
-                    self.expand.toggle() // Use your expanding logic here
-                }) {
+                #endif
+            } else {
+                #if os(iOS)
+                    Button(action: {
+                        self.expand.toggle()
+                    }) {
+                        contents
+                    }
+                #else
                     contents
-                }
-            #else
-                contents
-            #endif
+                #endif
+            }
         }
     }
 

--- a/Shared/Player/Video Details/ChaptersView.swift
+++ b/Shared/Player/Video Details/ChaptersView.swift
@@ -29,7 +29,7 @@ struct ChaptersView: View {
                     .listStyle(.plain)
                 #else
                     ScrollView(.horizontal) {
-                        LazyHStack(spacing: 20) { chapterViews(for: chapters.prefix(3), opacity: 1.0) }.padding(.horizontal, 15)
+                        LazyHStack(spacing: 20) { chapterViews(for: chapters[...]) }.padding(.horizontal, 15)
                     }
                 #endif
             } else if expand {
@@ -40,7 +40,7 @@ struct ChaptersView: View {
                         }
                     }
                 #else
-                    Section { chapterViews(for: chapters[...], opacity: 1.0) }.padding(.horizontal)
+                    Section { chapterViews(for: chapters[...]) }.padding(.horizontal)
                 #endif
             } else {
                 #if os(iOS)
@@ -48,12 +48,12 @@ struct ChaptersView: View {
                         self.expand.toggle()
                     }) {
                         Section {
-                            chapterViews(for: chapters.prefix(3), opacity: 0.3)
+                            chapterViews(for: chapters.prefix(3), opacity: 0.3, clickable: false)
                         }.padding(.horizontal)
                     }
                 #elseif os(macOS)
                     Section {
-                        chapterViews(for: chapters.prefix(3), opacity: 0.3)
+                        chapterViews(for: chapters.prefix(3), opacity: 0.3, clickable: false)
                     }.padding(.horizontal)
                 #else
                     Section {
@@ -67,12 +67,13 @@ struct ChaptersView: View {
     }
 
     #if !os(tvOS)
-        private func chapterViews(for chaptersToShow: ArraySlice<Chapter>, opacity: Double = 1.0) -> some View {
+        private func chapterViews(for chaptersToShow: ArraySlice<Chapter>, opacity: Double = 1.0, clickable: Bool = true) -> some View {
             ForEach(Array(chaptersToShow.indices), id: \.self) { index in
                 let chapter = chaptersToShow[index]
                 let nextChapterStart: Double? = index < chaptersToShow.count - 1 ? chaptersToShow[index + 1].start : nil
                 ChapterView(chapter: chapter, nextChapterStart: nextChapterStart, chapterIndex: index)
                     .opacity(index == 0 ? 1.0 : opacity)
+                    .allowsHitTesting(clickable)
             }
         }
     #endif

--- a/Shared/Player/Video Details/VideoDetails.swift
+++ b/Shared/Player/Video Details/VideoDetails.swift
@@ -169,6 +169,7 @@ struct VideoDetails: View {
     @State private var subscriptionToggleButtonDisabled = false
     @State private var page = DetailsPage.info
     @State private var descriptionExpanded = false
+    @State private var chaptersExpanded = false
 
     @Environment(\.navigationStyle) private var navigationStyle
     #if os(iOS)
@@ -317,10 +318,9 @@ struct VideoDetails: View {
                                 if player.videoBeingOpened.isNil {
                                     if showChapters,
                                        !video.isLocal,
-                                       !video.chapters.isEmpty
-                                    {
+                                       !video.chapters.isEmpty {
                                         Section(header: chaptersHeader) {
-                                            ChaptersView()
+                                            ChaptersView(expand: $chaptersExpanded)
                                         }
                                     }
 
@@ -331,8 +331,7 @@ struct VideoDetails: View {
 
                                     if showRelated,
                                        !sidebarQueue,
-                                       !(player.videoForDisplay?.related.isEmpty ?? true)
-                                    {
+                                       !(player.videoForDisplay?.related.isEmpty ?? true) {
                                         RelatedView()
                                             .padding(.horizontal)
                                             .padding(.top, 20)
@@ -390,8 +389,7 @@ struct VideoDetails: View {
             if showScrollToTopInComments,
                page == .comments,
                comments.loaded,
-               comments.all.count > 3
-            {
+               comments.all.count > 3 {
                 Button {
                     withAnimation {
                         proxy.scrollTo(Self.pageMenuID)
@@ -441,10 +439,17 @@ struct VideoDetails: View {
     }
 
     var chaptersHeader: some View {
-        Text("Chapters".localized())
-            .padding(.horizontal)
-            .font(.caption)
-            .foregroundColor(.secondary)
+        HStack {
+            Text("Chapters".localized())
+            Spacer()
+            Button(action: { chaptersExpanded.toggle() }) {
+                Image(systemName: chaptersExpanded ? "chevron.up" : "chevron.down")
+                    .imageScale(.small)
+            }
+        }
+        .padding(.horizontal)
+        .font(.caption)
+        .foregroundColor(.secondary)
     }
 }
 

--- a/Shared/Player/Video Details/VideoDetails.swift
+++ b/Shared/Player/Video Details/VideoDetails.swift
@@ -441,34 +441,48 @@ struct VideoDetails: View {
         #endif
     }
 
+    var chaptersHaveImages: Bool {
+        player.videoForDisplay?.chapters.allSatisfy { $0.image != nil } ?? false
+    }
+
     var chaptersHeader: some View {
-        #if canImport(UIKit)
-            Button(action: {
-                chaptersExpanded.toggle()
-            }) {
-                HStack {
-                    Text("Chapters".localized())
-                    Spacer()
-                    Image(systemName: chaptersExpanded ? "chevron.up" : "chevron.down")
-                        .imageScale(.small)
-                }
-                .padding(.horizontal)
-                .font(.caption)
-                .foregroundColor(.secondary)
-            }
-        #elseif canImport(AppKit)
-            HStack {
+        Group {
+            if !chaptersHaveImages {
+                #if canImport(UIKit)
+                    Button(action: {
+                        chaptersExpanded.toggle()
+                    }) {
+                        HStack {
+                            Text("Chapters".localized())
+                            Spacer()
+                            Image(systemName: chaptersExpanded ? "chevron.up" : "chevron.down")
+                                .imageScale(.small)
+                        }
+                        .padding(.horizontal)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    }
+                #elseif canImport(AppKit)
+                    HStack {
+                        Text("Chapters".localized())
+                        Spacer()
+                        Button(action: { chaptersExpanded.toggle() }) {
+                            Image(systemName: chaptersExpanded ? "chevron.up" : "chevron.down")
+                                .imageScale(.small)
+                        }
+                    }
+                    .padding(.horizontal)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                #endif
+            } else {
+                // No button, just the title when there are images
                 Text("Chapters".localized())
-                Spacer()
-                Button(action: { chaptersExpanded.toggle() }) {
-                    Image(systemName: chaptersExpanded ? "chevron.up" : "chevron.down")
-                        .imageScale(.small)
-                }
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal)
             }
-            .padding(.horizontal)
-            .font(.caption)
-            .foregroundColor(.secondary)
-        #endif
+        }
     }
 }
 

--- a/Shared/Player/Video Details/VideoDetails.swift
+++ b/Shared/Player/Video Details/VideoDetails.swift
@@ -318,7 +318,8 @@ struct VideoDetails: View {
                                 if player.videoBeingOpened.isNil {
                                     if showChapters,
                                        !video.isLocal,
-                                       !video.chapters.isEmpty {
+                                       !video.chapters.isEmpty
+                                    {
                                         Section(header: chaptersHeader) {
                                             ChaptersView(expand: $chaptersExpanded)
                                         }
@@ -331,7 +332,8 @@ struct VideoDetails: View {
 
                                     if showRelated,
                                        !sidebarQueue,
-                                       !(player.videoForDisplay?.related.isEmpty ?? true) {
+                                       !(player.videoForDisplay?.related.isEmpty ?? true)
+                                    {
                                         RelatedView()
                                             .padding(.horizontal)
                                             .padding(.top, 20)
@@ -389,7 +391,8 @@ struct VideoDetails: View {
             if showScrollToTopInComments,
                page == .comments,
                comments.loaded,
-               comments.all.count > 3 {
+               comments.all.count > 3
+            {
                 Button {
                     withAnimation {
                         proxy.scrollTo(Self.pageMenuID)

--- a/Shared/Player/Video Details/VideoDetails.swift
+++ b/Shared/Player/Video Details/VideoDetails.swift
@@ -442,17 +442,33 @@ struct VideoDetails: View {
     }
 
     var chaptersHeader: some View {
-        HStack {
-            Text("Chapters".localized())
-            Spacer()
-            Button(action: { chaptersExpanded.toggle() }) {
-                Image(systemName: chaptersExpanded ? "chevron.up" : "chevron.down")
-                    .imageScale(.small)
+        #if canImport(UIKit)
+            Button(action: {
+                chaptersExpanded.toggle()
+            }) {
+                HStack {
+                    Text("Chapters".localized())
+                    Spacer()
+                    Image(systemName: chaptersExpanded ? "chevron.up" : "chevron.down")
+                        .imageScale(.small)
+                }
+                .padding(.horizontal)
+                .font(.caption)
+                .foregroundColor(.secondary)
             }
-        }
-        .padding(.horizontal)
-        .font(.caption)
-        .foregroundColor(.secondary)
+        #elseif canImport(AppKit)
+            HStack {
+                Text("Chapters".localized())
+                Spacer()
+                Button(action: { chaptersExpanded.toggle() }) {
+                    Image(systemName: chaptersExpanded ? "chevron.up" : "chevron.down")
+                        .imageScale(.small)
+                }
+            }
+            .padding(.horizontal)
+            .font(.caption)
+            .foregroundColor(.secondary)
+        #endif
     }
 }
 

--- a/Shared/Player/Video Details/VideoDetails.swift
+++ b/Shared/Player/Video Details/VideoDetails.swift
@@ -1,4 +1,3 @@
-import CoreMedia
 import Defaults
 import Foundation
 import SDWebImageSwiftUI
@@ -484,15 +483,6 @@ struct VideoDetails: View {
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .padding(.horizontal)
-            }
-        }
-        .onReceive(
-            NotificationCenter.default
-                .publisher(for: .getTimeUpdatesNotification)
-                .receive(on: DispatchQueue.main)
-        ) { notification in
-            if let cmTime = notification.object as? CMTime {
-                player.updateTime(cmTime)
             }
         }
     }

--- a/Shared/Player/Video Details/VideoDetails.swift
+++ b/Shared/Player/Video Details/VideoDetails.swift
@@ -191,6 +191,7 @@ struct VideoDetails: View {
         @Default(.showScrollToTopInComments) private var showScrollToTopInComments
     #endif
     @Default(.expandVideoDescription) private var expandVideoDescription
+    @Default(.expandChapters) private var expandChapters
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -246,6 +247,7 @@ struct VideoDetails: View {
         .background(colorScheme == .dark ? Color.black : .white)
         .onAppear {
             descriptionExpanded = expandVideoDescription
+            chaptersExpanded = expandChapters
         }
     }
 

--- a/Shared/Player/Video Details/VideoDetails.swift
+++ b/Shared/Player/Video Details/VideoDetails.swift
@@ -1,3 +1,4 @@
+import CoreMedia
 import Defaults
 import Foundation
 import SDWebImageSwiftUI
@@ -483,6 +484,15 @@ struct VideoDetails: View {
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .padding(.horizontal)
+            }
+        }
+        .onReceive(
+            NotificationCenter.default
+                .publisher(for: .getTimeUpdatesNotification)
+                .receive(on: DispatchQueue.main)
+        ) { notification in
+            if let cmTime = notification.object as? CMTime {
+                player.updateTime(cmTime)
             }
         }
     }

--- a/Shared/Settings/PlayerSettings.swift
+++ b/Shared/Settings/PlayerSettings.swift
@@ -282,7 +282,7 @@ struct PlayerSettings: View {
         }
 
         private var showChaptersToggle: some View {
-            Toggle("Chapters", isOn: $showChapters)
+            Toggle("Chapters (if available)", isOn: $showChapters)
         }
 
         private var showRelatedToggle: some View {

--- a/Shared/Settings/PlayerSettings.swift
+++ b/Shared/Settings/PlayerSettings.swift
@@ -32,6 +32,7 @@ struct PlayerSettings: View {
 
     @Default(.showInspector) private var showInspector
     @Default(.showChapters) private var showChapters
+    @Default(.expandChapters) private var expandChapters
     @Default(.showRelated) private var showRelated
 
     @ObservedObject private var accounts = AccountsModel.shared
@@ -80,6 +81,7 @@ struct PlayerSettings: View {
                     expandVideoDescriptionToggle
                     collapsedLineDescriptionStepper
                     showChaptersToggle
+                    expandChaptersToggle
                     showRelatedToggle
                     #if os(macOS)
                         HStack {
@@ -283,6 +285,12 @@ struct PlayerSettings: View {
 
         private var showChaptersToggle: some View {
             Toggle("Chapters (if available)", isOn: $showChapters)
+        }
+
+        private var expandChaptersToggle: some View {
+            Toggle("Open vertical chapters expanded", isOn: $expandChapters)
+                .disabled(!showChapters)
+                .foregroundColor(showChapters ? .primary : .secondary)
         }
 
         private var showRelatedToggle: some View {

--- a/tvOS/NowPlayingView.swift
+++ b/tvOS/NowPlayingView.swift
@@ -130,7 +130,7 @@ struct NowPlayingView: View {
                         } else {
                             Section(header: Text("Chapters")) {
                                 ForEach(video.chapters) { chapter in
-                                    ChapterView(chapter: chapter)
+                                    ChapterViewTVOS(chapter: chapter)
                                         .padding(.horizontal, 40)
                                 }
                             }


### PR DESCRIPTION
Chapters are now collapsible by default only the first two chapters are shown. The second will be shown opaque to indicate more chapters.

Also highlights the current chapter, closes #422

on macOS:

![CleanShot 2023-11-21 at 15 06 22](https://github.com/yattee/yattee/assets/2091312/6d49b7b1-58f7-4c6d-a1c4-592a282f7b7a)

on iOS:

![CleanShot 2023-11-21 at 15 24 45](https://github.com/yattee/yattee/assets/2091312/748ec835-e7be-41db-a3a7-686236e8f59d)
