### PR TITLE
disable portraitUpsideDown on iPhones

### DIFF
--- a/iOS/OrientationTracker.swift
+++ b/iOS/OrientationTracker.swift
@@ -86,9 +86,11 @@ public class OrientationTracker {
         if accelerometerData.acceleration.y <= -threshold {
             return .portrait
         }
-        if accelerometerData.acceleration.y >= threshold {
+
+        if UIDevice.current.userInterfaceIdiom == .pad && accelerometerData.acceleration.y >= threshold {
             return .portraitUpsideDown
         }
+
         return currentDeviceOrientation
     }
 }


### PR DESCRIPTION
On iPhones, the portraitUpsideDown mode is not supported, as it is on iPads. Which means, when `Honor orientation lock` in the player settings is disabled, turning the phone from landscape to upside-down switches the view to normal Portrait Mode.

With this change, on iPhones, the video stays in landscape mode and only returns to portrait if the phone is held in normal portrait orientation. On iPads, it behaves as normal.

fixes #358