### PR TITLE
macOS: disable hit testing when not expanded

### DIFF
--- a/Shared/Player/Video Details/VideoDescription.swift
+++ b/Shared/Player/Video Details/VideoDescription.swift
@@ -56,27 +56,24 @@ struct VideoDescription: View {
         }
     }
 
-    var shouldExpand: Bool {
-        expand
-    }
-
     @ViewBuilder var textDescription: some View {
         #if canImport(AppKit)
             Group {
                 if #available(macOS 12, *) {
                     DescriptionWithLinks(description: description, detailsSize: detailsSize)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .lineLimit(shouldExpand ? 500 : collapsedLinesDescription)
+                        .lineLimit(expand ? 500 : collapsedLinesDescription)
                         .textSelection(.enabled)
                 } else {
                     Text(description)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .lineLimit(shouldExpand ? 500 : collapsedLinesDescription)
+                        .lineLimit(expand ? 500 : collapsedLinesDescription)
                 }
             }
             .multilineTextAlignment(.leading)
             .font(.system(size: 14))
             .lineSpacing(3)
+            .allowsHitTesting(expand)
         #endif
     }
 


### PR DESCRIPTION
fixes overspilling of text when clicking on collapsed descriptions

before:

![CleanShot 2023-12-05 at 00 29 01](https://github.com/yattee/yattee/assets/2091312/f770442b-6674-4035-87ae-b0049df98118)

after:
![CleanShot 2023-12-05 at 00 34 14](https://github.com/yattee/yattee/assets/2091312/9af96b0a-ded7-4ba8-889f-a0baca60179e)
