### PR TITLE
[WIP] allow ignoring certificate errors

### DIFF
--- a/Shared/Settings/AccountForm.swift
+++ b/Shared/Settings/AccountForm.swift
@@ -27,7 +27,7 @@ struct AccountForm: View {
                     VStack {
                         validationStatus
                     }
-                    .frame(minHeight: 60, alignment: .topLeading)
+                    .frame(alignment: .topLeading)
                     .padding(.horizontal, 15)
                 #endif
                 footer
@@ -40,7 +40,7 @@ struct AccountForm: View {
         .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
         .background(Color.background(scheme: colorScheme))
         #else
-        .frame(width: 400, height: 180)
+        .frame(width: 400)
         .padding(.vertical)
         #endif
     }
@@ -50,13 +50,13 @@ struct AccountForm: View {
             Text("Add Account")
                 .font(.title2.bold())
 
-            Spacer()
+            #if !os(macOS)
+                Spacer()
 
-            Button("Cancel") {
-                presentationMode.wrappedValue.dismiss()
-            }
-            #if !os(tvOS)
-            .keyboardShortcut(.cancelAction)
+                Button("Cancel") {
+                    presentationMode.wrappedValue.dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
             #endif
         }
         .padding(.horizontal)
@@ -118,6 +118,13 @@ struct AccountForm: View {
     var footer: some View {
         HStack {
             Spacer()
+
+            #if os(macOS)
+                Button("Cancel") {
+                    presentationMode.wrappedValue.dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+            #endif
 
             Button("Save", action: submitForm)
                 .disabled(!isValid)

--- a/Shared/Settings/InstanceForm.swift
+++ b/Shared/Settings/InstanceForm.swift
@@ -32,7 +32,7 @@ struct InstanceForm: View {
                     VStack {
                         validationStatus
                     }
-                    .frame(minHeight: 60, alignment: .topLeading)
+                    .frame(alignment: .topLeading)
                     .padding(.horizontal, 15)
                 #endif
                 footer
@@ -47,7 +47,7 @@ struct InstanceForm: View {
             .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
             .background(Color.background(scheme: colorScheme))
         #else
-            .frame(width: 400, height: 180)
+            .frame(width: 400)
             .padding(.vertical)
         #endif
     }
@@ -56,14 +56,13 @@ struct InstanceForm: View {
         HStack {
             Text("Add Location")
                 .font(.title2.bold())
+            #if !os(macOS)
+                Spacer()
 
-            Spacer()
-
-            Button("Cancel") {
-                presentationMode.wrappedValue.dismiss()
-            }
-            #if !os(tvOS)
-            .keyboardShortcut(.cancelAction)
+                Button("Cancel") {
+                    presentationMode.wrappedValue.dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
             #endif
         }
         .padding(.horizontal)
@@ -185,6 +184,13 @@ struct InstanceForm: View {
     private var footer: some View {
         HStack {
             Spacer()
+
+            #if os(macOS)
+                Button("Cancel") {
+                    presentationMode.wrappedValue.dismiss()
+                }
+                .keyboardShortcut(.defaultAction)
+            #endif
 
             Button("Save", action: submitForm)
                 .disabled(!isValid)


### PR DESCRIPTION
This is a work in progress.

I added the ability to select the URL scheme. Pasting entering a URL without http(s) will prefix the selected scheme. If the scheme is entered, it will automatically select the correct one.

Furthermore, it is possible to ignore certificate errors. This comes with a major warning and is not fully tested, and it is currently only implemented for adding a new instance. There are probably changes to be made somewhere else in the code.

This PR addresses #348 

Here is a brief example of how it works:

![CleanShot 2023-12-05 at 21 35 59](https://github.com/yattee/yattee/assets/2091312/c245faaf-6d9d-4d1c-96fe-ee7b23b9fa98)
