### PR TITLE
[WIP] Add playlist pagination support

### DIFF
--- a/Model/Applications/InvidiousAPI.swift
+++ b/Model/Applications/InvidiousAPI.swift
@@ -312,7 +312,14 @@ final class InvidiousAPI: Service, ObservableObject, VideosAPI {
     }
 
     func playlist(_ id: String) -> Resource? {
-        resource(baseURL: account.url, path: basePathAppending("auth/playlists/\(id)"))
+        return playlist(id, page: nil)
+    }
+    
+    func playlist(_ id: String, page: String? = nil) -> Resource? {
+        let resource = resource(baseURL: account.url, path: basePathAppending("auth/playlists/\(id)"))
+        guard let page else { return resource }
+        
+        return resource.withParam("page", page)
     }
 
     func playlistVideos(_ id: String) -> Resource? {

--- a/Model/Applications/PeerTubeAPI.swift
+++ b/Model/Applications/PeerTubeAPI.swift
@@ -316,6 +316,11 @@ final class PeerTubeAPI: Service, ObservableObject, VideosAPI {
     }
 
     func playlist(_ id: String) -> Resource? {
+        return playlist(id, page: nil)
+    }
+    
+    func playlist(_ id: String, page: String? = nil) -> Resource? {
+        // TODO
         resource(baseURL: account.url, path: basePathAppending("auth/playlists/\(id)"))
     }
 

--- a/Model/Applications/PipedAPI.swift
+++ b/Model/Applications/PipedAPI.swift
@@ -293,6 +293,11 @@ final class PipedAPI: Service, ObservableObject, VideosAPI {
     }
 
     func playlist(_ id: String) -> Resource? {
+        return playlist(id, page: nil)
+    }
+    
+    func playlist(_ id: String, page: String? = nil) -> Resource? {
+        // TODO
         channelPlaylist(id)
     }
 

--- a/Model/Applications/VideosAPI.swift
+++ b/Model/Applications/VideosAPI.swift
@@ -28,6 +28,7 @@ protocol VideosAPI {
     func unsubscribe(_ channelID: String, onCompletion: @escaping () -> Void)
 
     func playlist(_ id: String) -> Resource?
+    func playlist(_ id: String, page: String?) -> Resource?
     func playlistVideo(_ playlistID: String, _ videoID: String) -> Resource?
     func playlistVideos(_ id: String) -> Resource?
 

--- a/Shared/Playlists/PlaylistsView.swift
+++ b/Shared/Playlists/PlaylistsView.swift
@@ -195,9 +195,14 @@ struct PlaylistsView: View {
             response in
             if let nextPagePlaylist: Playlist = response.typedContent() {
                 if !nextPagePlaylist.videos.isEmpty {
-                    var currentPlaylist = self.userPlaylist.item
-                    currentPlaylist!.videos.append(contentsOf: nextPagePlaylist.videos)
-                    self.userPlaylist.replace(currentPlaylist!)
+                    var updatedPlaylist = self.userPlaylist.item
+                    let currentVideoIDs = Set(updatedPlaylist?.videos.map { $0.videoID } ?? [])
+                    // XXX: Invidious API returns duplicit videos, remove once fixed on Invidious side
+                    let newVideos = nextPagePlaylist.videos.filter { !currentVideoIDs.contains($0.videoID) }
+                    updatedPlaylist?.videos.append(contentsOf: newVideos)
+                    if !newVideos.isEmpty {
+                        self.userPlaylist.replace(updatedPlaylist!)
+                    }
                 } else {
                     self.canFetchMoreData = false
                 }

--- a/Shared/Playlists/PlaylistsView.swift
+++ b/Shared/Playlists/PlaylistsView.swift
@@ -10,6 +10,9 @@ struct PlaylistsView: View {
 
     @State private var showingEditPlaylist = false
     @State private var editedPlaylist: Playlist?
+    
+    @State private var currentPage = 1
+    @State private var canFetchMoreData = true
 
     @StateObject private var channelPlaylist = Store<ChannelPlaylist>()
     @StateObject private var userPlaylist = Store<Playlist>()
@@ -26,20 +29,16 @@ struct PlaylistsView: View {
     @Default(.showCacheStatus) private var showCacheStatus
 
     var items: [ContentItem] {
-        var videos = currentPlaylist?.videos ?? []
+        var videos = userPlaylist.item?.videos ?? channelPlaylist.item?.videos ?? []
 
-        if videos.isEmpty {
-            videos = userPlaylist.item?.videos ?? channelPlaylist.item?.videos ?? []
+        if !accounts.app.userPlaylistsEndpointIncludesVideos {
+            var i = 0
 
-            if !accounts.app.userPlaylistsEndpointIncludesVideos {
-                var i = 0
-
-                for index in videos.indices {
-                    var video = videos[index]
-                    video.indexID = "\(i)"
-                    i += 1
-                    videos[index] = video
-                }
+            for index in videos.indices {
+                var video = videos[index]
+                video.indexID = "\(i)"
+                i += 1
+                videos[index] = video
             }
         }
 
@@ -64,6 +63,7 @@ struct PlaylistsView: View {
         SignInRequiredView(title: "Playlists".localized()) {
             VStack {
                 VerticalCells(items: items, allowEmpty: true) { if shouldDisplayHeader { header } }
+                    .environment(\.loadMoreContentHandler) { loadNextPage() }
                     .environment(\.currentPlaylistID, currentPlaylist?.id)
                     .environment(\.listingStyle, playlistListingStyle)
 
@@ -75,19 +75,27 @@ struct PlaylistsView: View {
             }
         }
         .onAppear {
+            self.currentPage = 1
+            self.canFetchMoreData = true
             model.load()
             loadResource()
         }
         .onChange(of: accounts.current) { _ in
+            self.currentPage = 1
+            self.canFetchMoreData = true
             model.load(force: true)
             loadResource()
         }
         .onChange(of: currentPlaylist) { _ in
+            self.currentPage = 1
+            self.canFetchMoreData = true
             channelPlaylist.clear()
             userPlaylist.clear()
             loadResource()
         }
         .onChange(of: model.reloadPlaylists) { _ in
+            self.currentPage = 1
+            self.canFetchMoreData = true
             loadResource()
         }
         #if os(iOS)
@@ -176,6 +184,27 @@ struct PlaylistsView: View {
             }
     }
 
+    func loadNextPage() {
+        guard canFetchMoreData else {
+            return	
+        }
+        guard let playlist = currentPlaylist else { return }
+        
+        self.currentPage += 1
+        accounts.api.playlist(playlist.id, page: String(currentPage))?.load().onSuccess {
+            response in
+            if let nextPagePlaylist: Playlist = response.typedContent() {
+                if !nextPagePlaylist.videos.isEmpty {
+                    var currentPlaylist = self.userPlaylist.item
+                    currentPlaylist!.videos.append(contentsOf: nextPagePlaylist.videos)
+                    self.userPlaylist.replace(currentPlaylist!)
+                } else {
+                    self.canFetchMoreData = false
+                }
+            }
+        }
+    }
+    
     func loadCachedResource() {
         if !selectedPlaylistID.isEmpty,
            let currentPlaylist,


### PR DESCRIPTION
## Overview
Closes https://github.com/yattee/yattee/issues/586.
Adds support for playlist pagination.

- [x] **Invidious**
Invidious API [does not provide pagination data](https://docs.invidious.io/api/#get-apiv1playlistsplid), only `videoCount` parameter in response. 
Moreover, I've found that it contains duplicities (probably a bug?).
Thus, we can only try to fetch the next page, check if there are any videos present and if so, filter out duplicites.

- [ ]  **PeerTube**
It [uses count and start query parameters ](https://docs.joinpeertube.org/api-rest-reference.html#tag/Video-Playlists/operation/getVideoPlaylistVideos) to set number of returned items and offset used to paginate the result.
It also returns `total` - number of videos in playlist.

- [ ] **Piped**
Piped API [uses nextpage query parameter](https://docs.piped.video/docs/api-documentation/) for playlist pagination.