### PR TITLE
Show/hide recents and limit number of recents shown

### DIFF
--- a/Model/Import Export Settings/Exporters/HistorySettingsGroupExporter.swift
+++ b/Model/Import Export Settings/Exporters/HistorySettingsGroupExporter.swift
@@ -15,7 +15,11 @@ final class HistorySettingsGroupExporter: SettingsGroupExporter {
 
             "watchedVideoStyle": Defaults[.watchedVideoStyle].rawValue,
             "watchedVideoBadgeColor": Defaults[.watchedVideoBadgeColor].rawValue,
-            "showToggleWatchedStatusButton": Defaults[.showToggleWatchedStatusButton]
+            "showToggleWatchedStatusButton": Defaults[.showToggleWatchedStatusButton],
+
+            "showRecents": Defaults[.showRecents],
+            "limitRecents": Defaults[.limitRecents],
+            "limitRecentsAmount": Defaults[.limitRecentsAmount]
         ]
     }
 }

--- a/Model/Import Export Settings/Importers/HistorySettingsGroupImporter.swift
+++ b/Model/Import Export Settings/Importers/HistorySettingsGroupImporter.swift
@@ -50,5 +50,17 @@ struct HistorySettingsGroupImporter {
         if let showToggleWatchedStatusButton = json["showToggleWatchedStatusButton"].bool {
             Defaults[.showToggleWatchedStatusButton] = showToggleWatchedStatusButton
         }
+
+        if let showRecents = json["showRecents"].bool {
+            Defaults[.showRecents] = showRecents
+        }
+
+        if let limitRecents = json["limitRecents"].bool {
+            Defaults[.limitRecents] = limitRecents
+        }
+
+        if let limitRecentsAmount = json["limitRecentsAmount"].int {
+            Defaults[.limitRecentsAmount] = limitRecentsAmount
+        }
     }
 }

--- a/Shared/Defaults.swift
+++ b/Shared/Defaults.swift
@@ -225,6 +225,9 @@ extension Defaults.Keys {
 
     static let saveRecents = Key<Bool>("saveRecents", default: true)
     static let saveHistory = Key<Bool>("saveHistory", default: true)
+    static let showRecents = Key<Bool>("showRecents", default: true)
+    static let limitRecents = Key<Bool>("limitRecents", default: false)
+    static let limitRecentsAmount = Key<Int>("limitRecentsAmount", default: 10)
     static let showWatchingProgress = Key<Bool>("showWatchingProgress", default: true)
     static let saveLastPlayed = Key<Bool>("saveLastPlayed", default: false)
 

--- a/Shared/Navigation/AppSidebarRecents.swift
+++ b/Shared/Navigation/AppSidebarRecents.swift
@@ -5,12 +5,14 @@ struct AppSidebarRecents: View {
     var recents = RecentsModel.shared
 
     @Default(.recentlyOpened) private var recentItems
+    @Default(.limitRecents) private var limitRecents
+    @Default(.limitRecentsAmount) private var limitRecentsAmount
 
     var body: some View {
         Group {
             if !recentItems.isEmpty {
                 Section(header: Text("Recents")) {
-                    ForEach(recentItems.reversed()) { recent in
+                    ForEach(recentItems.reversed().prefix(limitRecents ? limitRecentsAmount : recentItems.count)) { recent in
                         Group {
                             switch recent.type {
                             case .channel:

--- a/Shared/Navigation/Sidebar.swift
+++ b/Shared/Navigation/Sidebar.swift
@@ -13,6 +13,7 @@ struct Sidebar: View {
         @Default(.showDocuments) private var showDocuments
     #endif
     @Default(.showUnwatchedFeedBadges) private var showUnwatchedFeedBadges
+    @Default(.showRecents) private var showRecents
 
     var body: some View {
         ScrollViewReader { scrollView in
@@ -20,8 +21,10 @@ struct Sidebar: View {
                 mainNavigationLinks
 
                 if !accounts.isEmpty {
-                    AppSidebarRecents()
-                        .id("recentlyOpened")
+                    if showRecents {
+                        AppSidebarRecents()
+                            .id("recentlyOpened")
+                    }
 
                     if accounts.api.signedIn {
                         if visibleSections.contains(.subscriptions), accounts.app.supportsSubscriptions {


### PR DESCRIPTION
This change adds a Setting in the History tab to allow the user to hide the recent activity in the sidebar, or limit the number of items shown.