### PR TITLE
Add help text to all header buttons

### DIFF
--- a/Shared/Settings/HomeSettings.swift
+++ b/Shared/Settings/HomeSettings.swift
@@ -66,6 +66,7 @@ struct HomeSettings: View {
                                     .font(.system(size: 30))
                                 #endif
                             }
+                            .help("Add to Favorites")
                             #if !os(tvOS)
                             .buttonStyle(.borderless)
                             #endif

--- a/Shared/Subscriptions/SubscriptionsView.swift
+++ b/Shared/Subscriptions/SubscriptionsView.swift
@@ -113,6 +113,7 @@ struct SubscriptionsView: View {
         } label: {
             Label("Play all unwatched", systemImage: "play")
         }
+        .help("Play all unwatched")
         .disabled(!feed.canPlayUnwatchedFeed)
     }
 
@@ -130,6 +131,7 @@ struct SubscriptionsView: View {
         } label: {
             Label("Mark all as watched", systemImage: "checkmark.circle.fill")
         }
+        .help("Mark all as watched")
         .disabled(!feed.canMarkAllFeedAsWatched)
     }
 
@@ -139,6 +141,7 @@ struct SubscriptionsView: View {
         } label: {
             Label("Mark all as unwatched", systemImage: "checkmark.circle")
         }
+        .help("Mark all as unwatched")
     }
 }
 

--- a/Shared/Views/FavoriteButton.swift
+++ b/Shared/Views/FavoriteButton.swift
@@ -37,6 +37,7 @@ struct FavoriteButton: View {
                     .contentShape(Rectangle())
                     #endif
                 }
+                .help(isFavorite ? "Remove from Favorites" : "Add to Favorites")
                 .disabled(item.isNil)
                 .onAppear {
                     isFavorite = item.isNil ? false : favorites.contains(item)

--- a/Shared/Views/HomeSettingsButton.swift
+++ b/Shared/Views/HomeSettingsButton.swift
@@ -11,6 +11,7 @@ struct HomeSettingsButton: View {
         }
         .font(.caption)
         .imageScale(.small)
+        .help("Home Settings")
     }
 }
 

--- a/Shared/Views/ListingStyleButtons.swift
+++ b/Shared/Views/ListingStyleButtons.swift
@@ -16,6 +16,7 @@ struct ListingStyleButtons: View {
                     .imageScale(.small)
                 #endif
             }
+            .help(listingStyle == .cells ? "List" : "Cells")
         #endif
     }
 

--- a/Shared/Views/ShareButton.swift
+++ b/Shared/Views/ShareButton.swift
@@ -38,6 +38,7 @@ struct ShareButton<LabelView: View>: View {
                 label
             }
             .menuStyle(.borderlessButton)
+            .help("Share")
             #if os(macOS)
                 .frame(maxWidth: 60)
             #endif


### PR DESCRIPTION
Added tooltips to the buttons in the header to let the user know what they do.