### PR TITLE
Fix #619: Remove ports from shared YouTube links

### DIFF
--- a/Model/Applications/VideosAPI.swift
+++ b/Model/Applications/VideosAPI.swift
@@ -108,10 +108,10 @@ extension VideosAPI {
             .onFailure { failureHandler?($0) }
     }
 
-    func shareURL(_ item: ContentItem, frontendURL: String? = nil, time: CMTime? = nil) -> URL? {
+    func shareURL(_ item: ContentItem, frontendURLString: String? = nil, time: CMTime? = nil) -> URL? {
         var urlComponents: URLComponents?
-        if let frontendURLString: String = frontendURL,
-            let frontendURL: URL = URL(string: frontendURLString) {
+        if let frontendURLString,
+            let frontendURL = URL(string: frontendURLString) {
             urlComponents = URLComponents(URL: frontendURL, resolvingAgainstBaseURL: false)
         } else if let instanceComponents = account?.instance?.urlComponents {
             urlComponents = instanceComponents

--- a/Model/Applications/VideosAPI.swift
+++ b/Model/Applications/VideosAPI.swift
@@ -66,7 +66,7 @@ protocol VideosAPI {
         failureHandler: ((RequestError) -> Void)?,
         completionHandler: @escaping (PlayerQueueItem) -> Void
     )
-    func shareURL(_ item: ContentItem, frontendHost: String?, time: CMTime?) -> URL?
+    func shareURL(_ item: ContentItem, frontendURL: String?, time: CMTime?) -> URL?
 
     func comments(_ id: Video.ID, page: String?) -> Resource?
 }
@@ -108,17 +108,17 @@ extension VideosAPI {
             .onFailure { failureHandler?($0) }
     }
 
-    func shareURL(_ item: ContentItem, frontendHost: String? = nil, time: CMTime? = nil) -> URL? {
-        guard let frontendHost = frontendHost ?? account?.instance?.frontendHost,
-              var urlComponents = account?.instance?.urlComponents
-        else {
-            return nil
+    func shareURL(_ item: ContentItem, frontendURL: String? = nil, time: CMTime? = nil) -> URL? {
+        var urlComponents: URLComponents?
+        if let frontendURLString: String = frontendURL,
+            let frontendURL: URL = URL(string: frontendURLString) {
+            urlComponents = URLComponents(URL: frontendURL, resolvingAgainstBaseURL: false)
+        } else if let instanceComponents = account?.instance?.urlComponents {
+            urlComponents = instanceComponents
         }
-
-        urlComponents.host = frontendHost
-
-        if frontendHost.contains("youtube.com") {
-            urlComponents.port = nil
+        
+        guard var urlComponents: URLComponents = urlComponents else {
+            return nil
         }
 
         var queryItems = [URLQueryItem]()

--- a/Model/Applications/VideosAPI.swift
+++ b/Model/Applications/VideosAPI.swift
@@ -117,6 +117,10 @@ extension VideosAPI {
 
         urlComponents.host = frontendHost
 
+        if frontendHost.contains("youtube.com") {
+            urlComponents.port = nil
+        }
+
         var queryItems = [URLQueryItem]()
 
         switch item.contentType {

--- a/Model/Applications/VideosAPI.swift
+++ b/Model/Applications/VideosAPI.swift
@@ -117,7 +117,7 @@ extension VideosAPI {
             urlComponents = instanceComponents
         }
         
-        guard var urlComponents: URLComponents = urlComponents else {
+        guard var urlComponents else {
             return nil
         }
 

--- a/Shared/Views/ShareButton.swift
+++ b/Shared/Views/ShareButton.swift
@@ -77,7 +77,7 @@ struct ShareButton<LabelView: View>: View {
 
     private var youtubeActions: some View {
         Group {
-            if let url = accounts.api.shareURL(contentItem, frontendHost: "www.youtube.com") {
+            if let url = accounts.api.shareURL(contentItem, frontendURL: "https://www.youtube.com") {
                 Button(labelForShareURL("YouTube")) {
                     shareAction(url)
                 }
@@ -87,7 +87,7 @@ struct ShareButton<LabelView: View>: View {
                         shareAction(
                             accounts.api.shareURL(
                                 contentItem,
-                                frontendHost: "www.youtube.com",
+                                frontendURL: "https://www.youtube.com",
                                 time: player.backend.currentTime
                             )!
                         )


### PR DESCRIPTION
Issue #619 describes how when the app is connected to a frontend hosted on a non-standard port, that port gets added to shared YouTube links.

This change removes ports from shared YouTube links.