### PR TITLE
fix handling and displaying captions

### DIFF
--- a/Model/Player/Backends/MPVBackend.swift
+++ b/Model/Player/Backends/MPVBackend.swift
@@ -264,6 +264,10 @@ final class MPVBackend: PlayerBackend {
 
                 self.startClientUpdates()
 
+                // Captions should only be displayed when selected by the user,
+                // not when the video starts. So, we remove them.
+                self.client?.removeSubs()
+
                 if !preservingTime,
                    !upgrading,
                    let segment = self.model.sponsorBlock.segments.first,

--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -1190,7 +1190,8 @@ final class PlayerModel: ObservableObject {
                     if !self.controls.isLoadingVideo {
                         self.backend.togglePlay()
                     }
-                default: return keyEvent
+                default:
+                    return keyEvent
                 }
                 return nil
             }

--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -176,7 +176,7 @@ final class PlayerModel: ObservableObject {
     @Default(.resetWatchedStatusOnPlaying) var resetWatchedStatusOnPlaying
     @Default(.playerRate) var playerRate
     @Default(.systemControlsSeekDuration) var systemControlsSeekDuration
-    
+
     #if os(macOS)
         @Default(.buttonBackwardSeekDuration) private var buttonBackwardSeekDuration
         @Default(.buttonForwardSeekDuration) private var buttonForwardSeekDuration
@@ -192,7 +192,7 @@ final class PlayerModel: ObservableObject {
     var onPlayStream = [(Stream) -> Void]()
     var rateToRestore: Float?
     private var remoteCommandCenterConfigured = false
-    
+
     #if os(macOS)
         var keyPressMonitor: Any?
     #endif
@@ -771,9 +771,11 @@ final class PlayerModel: ObservableObject {
 
     func handleCurrentItemChange() {
         if currentItem == nil {
-            captions = nil
             FeedModel.shared.calculateUnwatchedFeed()
         }
+
+        // Captions need to be set to nil on item change, to clear the previus values.
+        captions = nil
 
         #if os(macOS)
             Windows.player.window?.title = windowTitle
@@ -1158,7 +1160,7 @@ final class PlayerModel: ObservableObject {
 
         return nil
     }
-    
+
     #if os(macOS)
         private func assignKeyPressMonitor() {
             keyPressMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { keyEvent -> NSEvent? in
@@ -1193,7 +1195,7 @@ final class PlayerModel: ObservableObject {
                 return nil
             }
         }
-        
+
         private func destroyKeyPressMonitor() {
             if let keyPressMonitor = keyPressMonitor {
                 NSEvent.removeMonitor(keyPressMonitor)

--- a/Shared/Player/Controls/ControlsOverlay.swift
+++ b/Shared/Player/Controls/ControlsOverlay.swift
@@ -312,7 +312,6 @@ struct ControlsOverlay: View {
                     .foregroundColor(.primary)
             }
             .transaction { t in t.animation = .none }
-
             .buttonStyle(.plain)
             .foregroundColor(.primary)
             .frame(width: 240, height: 40)
@@ -374,12 +373,12 @@ struct ControlsOverlay: View {
         let captions = player.currentVideo?.captions ?? []
         Picker("Captions", selection: captionsBinding) {
             if captions.isEmpty {
-                Text("Not available")
+                Text("Not available").tag(Captions?.none)
             } else {
                 Text("Disabled").tag(Captions?.none)
-            }
-            ForEach(captions) { caption in
-                Text(caption.description).tag(Optional(caption))
+                ForEach(captions) { caption in
+                    Text(caption.description).tag(Optional(caption))
+                }
             }
         }
         .disabled(captions.isEmpty)

--- a/Shared/Player/PlaybackSettings.swift
+++ b/Shared/Player/PlaybackSettings.swift
@@ -433,12 +433,12 @@ struct PlaybackSettings: View {
         let captions = player.currentVideo?.captions ?? []
         Picker("Captions".localized(), selection: $player.captions) {
             if captions.isEmpty {
-                Text("Not available")
+                Text("Not available").tag(Captions?.none)
             } else {
                 Text("Disabled").tag(Captions?.none)
-            }
-            ForEach(captions) { caption in
-                Text(caption.description).tag(Optional(caption))
+                ForEach(captions) { caption in
+                    Text(caption.description).tag(Optional(caption))
+                }
             }
         }
         .disabled(captions.isEmpty)

--- a/Shared/Settings/Import/ImportSettings.swift
+++ b/Shared/Settings/Import/ImportSettings.swift
@@ -1,4 +1,3 @@
-
 import SwiftUI
 
 struct ImportSettings: View {


### PR DESCRIPTION
fixes #490

It also fixes the caption picker being empty when a caption was selected in the previous watched video.