### PR TITLE
upgrade MPVKit to pre 0.37.0 commit

### DIFF
--- a/Yattee.xcodeproj/project.pbxproj
+++ b/Yattee.xcodeproj/project.pbxproj
@@ -5004,7 +5004,7 @@
 			repositoryURL = "https://github.com/cxfksword/MPVKit.git";
 			requirement = {
 				kind = revision;
-				revision = dca1e345a26d09a3d621d7656a94e6427f3f7b83;
+				revision = 11f3fecac220c6ef41bd084541bf4d0e69fe3b31;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Yattee.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Yattee.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,7 +60,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/cxfksword/MPVKit.git",
       "state" : {
-        "revision" : "dca1e345a26d09a3d621d7656a94e6427f3f7b83"
+        "revision" : "11f3fecac220c6ef41bd084541bf4d0e69fe3b31"
       }
     },
     {
@@ -181,5 +181,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }


### PR DESCRIPTION
This is the last commit before MPVKit v0.37.0.
All commits/version afterwards have several issues when used in Yattee.