### PR TITLE
Restart finished video

### DIFF
--- a/Model/Player/Backends/AVPlayerBackend.swift
+++ b/Model/Player/Backends/AVPlayerBackend.swift
@@ -160,6 +160,13 @@ final class AVPlayerBackend: PlayerBackend {
             return
         }
 
+        // After the video has ended, hitting play restarts the video from the beginning.
+        if currentTime?.seconds.formattedAsPlaybackTime() == model.playerTime.duration.seconds.formattedAsPlaybackTime() &&
+            currentTime!.seconds > 0 && model.playerTime.duration.seconds > 0
+        {
+            seek(to: 0, seekType: .loopRestart)
+        }
+
         avPlayer.play()
         model.objectWillChange.send()
     }

--- a/Model/Player/Backends/MPVBackend.swift
+++ b/Model/Player/Backends/MPVBackend.swift
@@ -354,6 +354,13 @@ final class MPVBackend: PlayerBackend {
 
         setRate(model.currentRate)
 
+        // After the video has ended, hitting play restarts the video from the beginning.
+        if currentTime?.seconds.formattedAsPlaybackTime() == model.playerTime.duration.seconds.formattedAsPlaybackTime() &&
+            currentTime!.seconds > 0 && model.playerTime.duration.seconds > 0
+        {
+            seek(to: 0, seekType: .loopRestart)
+        }
+
         client?.play()
     }
 
@@ -519,8 +526,6 @@ final class MPVBackend: PlayerBackend {
         guard client.eofReached else {
             return
         }
-
-        getTimeUpdates()
         eofPlaybackModeAction()
     }
 


### PR DESCRIPTION
After the video has ended, hitting play restarts the video from the beginning

fixes https://github.com/yattee/yattee/issues/449

If I understand the issue correctly, however, videos can now be played again without hitting the "Start from the beginning" button.