### PR TITLE
move MP4 to the bottom and hide disabled formats

### DIFF
--- a/Model/QualityProfile.swift
+++ b/Model/QualityProfile.swift
@@ -8,10 +8,10 @@ struct QualityProfile: Hashable, Identifiable, Defaults.Serializable {
     enum Format: String, CaseIterable, Identifiable, Defaults.Serializable {
         case hls
         case stream
-        case mp4
         case avc1
         case av1
         case webm
+        case mp4
 
         var id: String {
             rawValue
@@ -35,14 +35,14 @@ struct QualityProfile: Hashable, Identifiable, Defaults.Serializable {
                 return nil
             case .stream:
                 return nil
-            case .mp4:
-                return .mp4
-            case .webm:
-                return .webm
             case .avc1:
                 return .avc1
             case .av1:
                 return .av1
+            case .webm:
+                return .webm
+            case .mp4:
+                return .mp4
             }
         }
     }

--- a/Model/Stream.swift
+++ b/Model/Stream.swift
@@ -83,21 +83,21 @@ class Stream: Equatable, Hashable, Identifiable {
     }
 
     enum Format: String, Comparable {
-        case webm
         case avc1
         case av1
+        case webm
         case mp4
         case unknown
 
         private var sortOrder: Int {
             switch self {
-            case .mp4:
-                return 0
             case .avc1:
-                return 1
+                return 0
             case .av1:
-                return 2
+                return 1
             case .webm:
+                return 2
+            case .mp4:
                 return 3
             case .unknown:
                 return 4
@@ -121,14 +121,14 @@ class Stream: Equatable, Hashable, Identifiable {
         static func from(_ string: String) -> Self {
             let lowercased = string.lowercased()
 
-            if lowercased.contains("webm") {
-                return .webm
-            }
             if lowercased.contains("avc1") {
                 return .avc1
             }
             if lowercased.contains("av01") {
                 return .av1
+            }
+            if lowercased.contains("webm") {
+                return .webm
             }
             if lowercased.contains("mpeg_4") || lowercased.contains("mp4") {
                 return .mp4

--- a/Shared/Settings/QualityProfileForm.swift
+++ b/Shared/Settings/QualityProfileForm.swift
@@ -199,17 +199,21 @@ struct QualityProfileForm: View {
         #endif
     }
 
+    var filteredFormatList: some View {
+        ForEach(QualityProfile.Format.allCases.filter { !isFormatDisabled($0) }, id: \.self) { format in
+            MultiselectRow(
+                title: format.description,
+                selected: isFormatSelected(format),
+                disabled: isFormatDisabled(format)
+            ) { value in
+                toggleFormat(format, value: value)
+            }
+        }
+    }
+
     @ViewBuilder var formatsPicker: some View {
         #if os(macOS)
-            let list = ForEach(QualityProfile.Format.allCases, id: \.self) { format in
-                MultiselectRow(
-                    title: format.description,
-                    selected: isFormatSelected(format),
-                    disabled: isFormatDisabled(format)
-                ) { value in
-                    toggleFormat(format, value: value)
-                }
-            }
+            let list = filteredFormatList
 
             Group {
                 if #available(macOS 12.0, *) {
@@ -222,15 +226,7 @@ struct QualityProfileForm: View {
             }
             Spacer()
         #else
-            ForEach(QualityProfile.Format.allCases, id: \.self) { format in
-                MultiselectRow(
-                    title: format.description,
-                    selected: isFormatSelected(format),
-                    disabled: isFormatDisabled(format)
-                ) { value in
-                    toggleFormat(format, value: value)
-                }
-            }
+            filteredFormatList
         #endif
     }
 


### PR DESCRIPTION
Currently, mp4 is one of the first formats chosen. But there are some issues when it comes to scrubbing/seeking. Therefore we only use mp4 as the last resort, this should give a better user experience.

sort of fixes #590 & #626 & #487

Also when choosing the AVPlayer in the Quality settings, disabled formats are hidden.

![IMG_1735](https://github.com/yattee/yattee/assets/2091312/26854958-172c-40c5-b7f7-da4ae62c642f)

![IMG_1736](https://github.com/yattee/yattee/assets/2091312/a3843e8e-dce2-4b63-96f1-c0b3fd72ceca)