### PR TITLE
SponsorBlock jump to end instead of pausing

### DIFF
--- a/Model/Player/PlayerSponsorBlock.swift
+++ b/Model/Player/PlayerSponsorBlock.swift
@@ -44,22 +44,6 @@ extension PlayerModel {
     }
 
     private func skip(_ segment: Segment, at time: CMTime) {
-        if let duration = playerItemDuration, segment.endTime.seconds >= duration.seconds - 3 {
-            logger.error("segment end time is: \(segment.end) when player item duration is: \(duration.seconds)")
-
-            DispatchQueue.main.async { [weak self] in
-                guard let self else {
-                    return
-                }
-
-                self.pause()
-
-                self.backend.eofPlaybackModeAction()
-            }
-
-            return
-        }
-
         backend.seek(to: segment.endTime, seekType: .segmentSkip(segment.category))
 
         DispatchQueue.main.async { [weak self] in
@@ -69,6 +53,14 @@ extension PlayerModel {
             self?.segmentRestorationTime = time
         }
         logger.info("SponsorBlock skipping to: \(segment.end)")
+
+        if let duration = playerItemDuration, segment.endTime.seconds >= duration.seconds - 3 {
+            logger.error("Segment end time is: \(segment.end) when player item duration is: \(duration.seconds)")
+
+            DispatchQueue.main.async { [weak self] in
+                self?.backend.eofPlaybackModeAction()
+            }
+        }
     }
 
     private func shouldSkip(_ segment: Segment, at time: CMTime) -> Bool {


### PR DESCRIPTION
When the time stamp for the last segment is greater than the duration, currently, the video pauses.

Now instead of pausing, we jump to the duration (end time) of the video instead.