### PR TITLE
fix Orientation handling

### DIFF
--- a/Model/Import Export Settings/Exporters/PlayerSettingsGroupExporter.swift
+++ b/Model/Import Export Settings/Exporters/PlayerSettingsGroupExporter.swift
@@ -41,7 +41,6 @@ final class PlayerSettingsGroupExporter: SettingsGroupExporter {
         #endif
 
         #if os(iOS)
-            export["honorSystemOrientationLock"].bool = Defaults[.honorSystemOrientationLock]
             export["enterFullscreenInLandscape"].bool = Defaults[.enterFullscreenInLandscape]
             export["rotateToLandscapeOnEnterFullScreen"].string = Defaults[.rotateToLandscapeOnEnterFullScreen].rawValue
         #endif

--- a/Model/Import Export Settings/Importers/PlayerSettingsGroupImporter.swift
+++ b/Model/Import Export Settings/Importers/PlayerSettingsGroupImporter.swift
@@ -90,10 +90,6 @@ struct PlayerSettingsGroupImporter {
         #endif
 
         #if os(iOS)
-            if let honorSystemOrientationLock = json["honorSystemOrientationLock"].bool {
-                Defaults[.honorSystemOrientationLock] = honorSystemOrientationLock
-            }
-
             if let enterFullscreenInLandscape = json["enterFullscreenInLandscape"].bool {
                 Defaults[.enterFullscreenInLandscape] = enterFullscreenInLandscape
             }

--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -131,6 +131,7 @@ final class PlayerModel: ObservableObject {
     #if os(iOS)
         @Published var lockedOrientation: UIInterfaceOrientationMask?
         @Default(.rotateToLandscapeOnEnterFullScreen) private var rotateToLandscapeOnEnterFullScreen
+        @Default(.honorSystemOrientationLock) private var honorSystemOrientationLock
     #endif
 
     @Published var currentChapterIndex: Int?
@@ -1092,7 +1093,10 @@ final class PlayerModel: ObservableObject {
                     avPlayerBackend.controller.enterFullScreen(animated: true)
                     return
                 }
-                guard rotateToLandscapeOnEnterFullScreen.isRotating else { return }
+
+                guard rotateToLandscapeOnEnterFullScreen.isRotating && honorSystemOrientationLock ||
+                    !honorSystemOrientationLock else { return }
+
                 if currentVideoIsLandscape {
                     let delay = activeBackend == .appleAVPlayer && avPlayerUsesSystemControls ? 0.8 : 0
                     Delay.by(delay) {

--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -129,7 +129,7 @@ final class PlayerModel: ObservableObject {
     }}
 
     #if os(iOS)
-        @Published var lockedOrientation: UIInterfaceOrientationMask?
+        @Published var isOrientationLocked = false
         @Default(.rotateToLandscapeOnEnterFullScreen) private var rotateToLandscapeOnEnterFullScreen
     #endif
 
@@ -777,16 +777,9 @@ final class PlayerModel: ObservableObject {
 
     #if os(iOS)
         var lockOrientationImage: String {
-            lockedOrientation.isNil ? "lock.rotation.open" : "lock.rotation"
+            isOrientationLocked ? "lock.rotation" : "lock.rotation.open"
         }
 
-        func lockOrientationAction() {
-            if lockedOrientation.isNil {
-                lockedOrientation = OrientationTracker.shared.currentInterfaceOrientationMask
-            } else {
-                lockedOrientation = nil
-            }
-        }
     #endif
 
     func replayAction() {

--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -652,6 +652,10 @@ final class PlayerModel: ObservableObject {
         closing = true
         controls.presentingControls = false
 
+        if playingFullScreen {
+            exitFullScreen()
+        }
+
         self.prepareCurrentItemForHistory(finished: finished)
 
         self.hide()

--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -995,12 +995,6 @@ final class PlayerModel: ObservableObject {
 
         logger.info("Entering fullscreen")
         toggleFullscreen(false, showControls: showControls)
-
-        // Request rotation if needed
-        if Defaults[.rotateToLandscapeOnEnterFullScreen].isRotating {
-            let orientation = Defaults[.rotateToLandscapeOnEnterFullScreen].interfaceOrientationSetting
-            Orientation.lockOrientation(.allButUpsideDown, andRotateTo: orientation)
-        }
     }
 
     func exitFullScreen(showControls: Bool = true) {
@@ -1008,13 +1002,6 @@ final class PlayerModel: ObservableObject {
 
         logger.info("Exiting fullscreen")
         toggleFullscreen(true, showControls: showControls)
-
-        // Optionally reset orientation to portrait
-        if Defaults[.lockPortraitWhenBrowsing] {
-            Orientation.lockOrientation(.portrait)
-        } else {
-            Orientation.lockOrientation(.allButUpsideDown)
-        }
     }
 
     func updateNowPlayingInfo() {
@@ -1107,7 +1094,9 @@ final class PlayerModel: ObservableObject {
 
                     let delay = activeBackend == .appleAVPlayer && avPlayerUsesSystemControls ? 0.8 : 0
                     Delay.by(delay) {
-                        let orientation = self.rotateToLandscapeOnEnterFullScreen.interfaceOrientationSetting
+                        let orientation = OrientationTracker.shared.currentInterfaceOrientation == .portrait
+                            ? self.rotateToLandscapeOnEnterFullScreen.interfaceOrientationSetting
+                            : OrientationTracker.shared.currentInterfaceOrientation
                         Orientation.lockOrientation(.allButUpsideDown, andRotateTo: orientation)
                     }
                 } else {

--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -792,7 +792,7 @@ final class PlayerModel: ObservableObject {
             if isOrientationLocked {
                 Orientation.lockOrientation(lockOrientation, andRotateTo: rotationOrientation)
             } else {
-                Orientation.lockOrientation(lockPortraitWhenBrowsing ? .allButUpsideDown : .all)
+                Orientation.lockOrientation(lockPortraitWhenBrowsing ? .allButUpsideDown : .all, andRotateTo: rotationOrientation)
             }
         }
 

--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -1096,7 +1096,7 @@ final class PlayerModel: ObservableObject {
                 if currentVideoIsLandscape {
                     let delay = activeBackend == .appleAVPlayer && avPlayerUsesSystemControls ? 0.8 : 0
                     Delay.by(delay) {
-                        let orientation = OrientationTracker.shared.currentDeviceOrientation.isLandscape ? OrientationTracker.shared.currentInterfaceOrientation : self.rotateToLandscapeOnEnterFullScreen.interaceOrientation
+                        let orientation = OrientationTracker.shared.currentDeviceOrientation.isLandscape ? OrientationTracker.shared.currentInterfaceOrientation : self.rotateToLandscapeOnEnterFullScreen.interfaceOrientationSetting
 
                         Orientation.lockOrientation(.allButUpsideDown, andRotateTo: orientation)
                     }

--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -506,7 +506,7 @@ final class PlayerModel: ObservableObject {
 
         #if os(iOS)
             if presentingPlayer, activeBackend == .appleAVPlayer, avPlayerUsesSystemControls, Constants.isIPhone {
-                Orientation.lockOrientation(.portrait, andRotateTo: .portrait)
+                Orientation.lockOrientation(.all, andRotateTo: .portrait)
             }
         #endif
 
@@ -532,7 +532,7 @@ final class PlayerModel: ObservableObject {
         if !presentingPlayer {
             #if os(iOS)
                 if Defaults[.lockPortraitWhenBrowsing] {
-                    Orientation.lockOrientation(.portrait, andRotateTo: .portrait)
+                    Orientation.lockOrientation(.all, andRotateTo: .portrait)
                 } else {
                     Orientation.lockOrientation(.allButUpsideDown)
                 }

--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -1095,10 +1095,9 @@ final class PlayerModel: ObservableObject {
                 guard rotateToLandscapeOnEnterFullScreen.isRotating else { return }
                 if currentVideoIsLandscape {
                     let delay = activeBackend == .appleAVPlayer && avPlayerUsesSystemControls ? 0.8 : 0
-                    // not sure why but first rotation call is ignore so doing rotate to same orientation first
                     Delay.by(delay) {
                         let orientation = OrientationTracker.shared.currentDeviceOrientation.isLandscape ? OrientationTracker.shared.currentInterfaceOrientation : self.rotateToLandscapeOnEnterFullScreen.interaceOrientation
-                        Orientation.lockOrientation(.allButUpsideDown, andRotateTo: OrientationTracker.shared.currentInterfaceOrientation)
+
                         Orientation.lockOrientation(.allButUpsideDown, andRotateTo: orientation)
                     }
                 }

--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -1089,12 +1089,9 @@ final class PlayerModel: ObservableObject {
 
                 // Check if rotation is needed when entering fullscreen
                 if Defaults[.enterFullscreenInLandscape] {
-                    // Rotate to landscape if needed and orientation is not locked
-                    guard lockedOrientation.isNil else { return }
-
-                    let delay = activeBackend == .appleAVPlayer && avPlayerUsesSystemControls ? 0.8 : 0
+                    let delay = activeBackend == .appleAVPlayer && avPlayerUsesSystemControls ? 0.8 : 0.1
                     Delay.by(delay) {
-                        let orientation = OrientationTracker.shared.currentInterfaceOrientation == .portrait
+                        let orientation = (OrientationTracker.shared.currentInterfaceOrientation == .portrait || OrientationTracker.shared.currentInterfaceOrientation == .portraitUpsideDown)
                             ? self.rotateToLandscapeOnEnterFullScreen.interfaceOrientationSetting
                             : OrientationTracker.shared.currentInterfaceOrientation
                         Orientation.lockOrientation(.allButUpsideDown, andRotateTo: orientation)
@@ -1115,8 +1112,11 @@ final class PlayerModel: ObservableObject {
                 }
 
                 // Reset orientation to portrait if on iPhone
-                let rotationOrientation: UIInterfaceOrientation? = Constants.isIPhone ? .portrait : nil
-                Orientation.lockOrientation(.allButUpsideDown, andRotateTo: rotationOrientation)
+                #if os(iOS)
+                    let rotationLock: UIInterfaceOrientationMask = Constants.isIPhone ? .allButUpsideDown : .all
+                    let rotationOrientation: UIInterfaceOrientation? = Defaults[.lockPortraitWhenBrowsing] ? .portrait : OrientationTracker.shared.currentInterfaceOrientation
+                    Orientation.lockOrientation(rotationLock, andRotateTo: rotationOrientation)
+                #endif
             }
         #endif
     }

--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -178,6 +178,7 @@ final class PlayerModel: ObservableObject {
     @Default(.resetWatchedStatusOnPlaying) var resetWatchedStatusOnPlaying
     @Default(.playerRate) var playerRate
     @Default(.systemControlsSeekDuration) var systemControlsSeekDuration
+    @Default(.lockPortraitWhenBrowsing) var lockPortraitWhenBrowsing
 
     #if os(macOS)
         @Default(.buttonBackwardSeekDuration) private var buttonBackwardSeekDuration
@@ -782,6 +783,17 @@ final class PlayerModel: ObservableObject {
     #if os(iOS)
         var lockOrientationImage: String {
             isOrientationLocked ? "lock.rotation" : "lock.rotation.open"
+        }
+
+        func toggleOrientationAction() {
+            isOrientationLocked.toggle()
+            let lockOrientation = OrientationTracker.shared.currentInterfaceOrientationMask
+            let rotationOrientation = OrientationTracker.shared.currentInterfaceOrientation
+            if isOrientationLocked {
+                Orientation.lockOrientation(lockOrientation, andRotateTo: rotationOrientation)
+            } else {
+                Orientation.lockOrientation(lockPortraitWhenBrowsing ? .allButUpsideDown : .all)
+            }
         }
 
     #endif

--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -131,7 +131,6 @@ final class PlayerModel: ObservableObject {
     #if os(iOS)
         @Published var lockedOrientation: UIInterfaceOrientationMask?
         @Default(.rotateToLandscapeOnEnterFullScreen) private var rotateToLandscapeOnEnterFullScreen
-        @Default(.honorSystemOrientationLock) private var honorSystemOrientationLock
     #endif
 
     @Published var currentChapterIndex: Int?
@@ -1088,8 +1087,7 @@ final class PlayerModel: ObservableObject {
                     return
                 }
 
-                guard rotateToLandscapeOnEnterFullScreen.isRotating && honorSystemOrientationLock && lockedOrientation.isNil ||
-                    !honorSystemOrientationLock else { return }
+                guard rotateToLandscapeOnEnterFullScreen.isRotating && lockedOrientation.isNil else { return }
 
                 if currentVideoIsLandscape {
                     let delay = activeBackend == .appleAVPlayer && avPlayerUsesSystemControls ? 0.8 : 0

--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -783,15 +783,9 @@ final class PlayerModel: ObservableObject {
 
         func lockOrientationAction() {
             if lockedOrientation.isNil {
-                let orientationMask = OrientationTracker.shared.currentInterfaceOrientationMask
-                lockedOrientation = orientationMask
-                let orientation = OrientationTracker.shared.currentInterfaceOrientation
-                Orientation.lockOrientation(orientationMask, andRotateTo: .landscapeLeft)
-                // iOS 16 workaround
-                Orientation.lockOrientation(orientationMask, andRotateTo: orientation)
+                lockedOrientation = OrientationTracker.shared.currentInterfaceOrientationMask
             } else {
                 lockedOrientation = nil
-                Orientation.lockOrientation(.allButUpsideDown, andRotateTo: OrientationTracker.shared.currentInterfaceOrientation)
             }
         }
     #endif
@@ -1094,7 +1088,7 @@ final class PlayerModel: ObservableObject {
                     return
                 }
 
-                guard rotateToLandscapeOnEnterFullScreen.isRotating && honorSystemOrientationLock ||
+                guard rotateToLandscapeOnEnterFullScreen.isRotating && honorSystemOrientationLock && lockedOrientation.isNil ||
                     !honorSystemOrientationLock else { return }
 
                 if currentVideoIsLandscape {

--- a/Shared/Defaults.swift
+++ b/Shared/Defaults.swift
@@ -522,7 +522,7 @@ enum FullScreenRotationSetting: String, CaseIterable, Defaults.Serializable {
     case landscapeRight
 
     #if os(iOS)
-        var interaceOrientation: UIInterfaceOrientation {
+        var interfaceOrientationSetting: UIInterfaceOrientation {
             switch self {
             case .landscapeLeft:
                 return .landscapeLeft

--- a/Shared/Defaults.swift
+++ b/Shared/Defaults.swift
@@ -20,14 +20,14 @@ extension Defaults.Keys {
     static let showOpenActionsToolbarItem = Key<Bool>("showOpenActionsToolbarItem", default: false)
     #if os(iOS)
         static let showDocuments = Key<Bool>("showDocuments", default: false)
-        static let lockPortraitWhenBrowsing = Key<Bool>("lockPortraitWhenBrowsing", default: UIDevice.current.userInterfaceIdiom == .phone)
+        static let lockPortraitWhenBrowsing = Key<Bool>("lockPortraitWhenBrowsing", default: Constants.isIPhone)
     #endif
 
     #if !os(tvOS)
         #if os(macOS)
             static let accountPickerDisplaysUsernameDefault = true
         #else
-            static let accountPickerDisplaysUsernameDefault = UIDevice.current.userInterfaceIdiom == .pad
+            static let accountPickerDisplaysUsernameDefault = Constants.isIPad
         #endif
         static let accountPickerDisplaysUsername = Key<Bool>("accountPickerDisplaysUsername", default: accountPickerDisplaysUsernameDefault)
     #endif
@@ -91,10 +91,10 @@ extension Defaults.Keys {
     static let enableReturnYouTubeDislike = Key<Bool>("enableReturnYouTubeDislike", default: false)
 
     #if os(iOS)
-        static let enterFullscreenInLandscape = Key<Bool>("enterFullscreenInLandscape", default: UIDevice.current.userInterfaceIdiom == .phone)
+        static let enterFullscreenInLandscape = Key<Bool>("enterFullscreenInLandscape", default: Constants.isIPhone)
         static let rotateToLandscapeOnEnterFullScreen = Key<FullScreenRotationSetting>(
             "rotateToLandscapeOnEnterFullScreen",
-            default: UIDevice.current.userInterfaceIdiom == .phone ? .landscapeRight : .disabled
+            default: Constants.isIPhone ? .landscapeRight : .disabled
         )
     #endif
 
@@ -119,8 +119,8 @@ extension Defaults.Keys {
     static let seekGestureSpeed = Key<Double>("seekGestureSpeed", default: 0.5)
 
     #if os(iOS)
-        static let playerControlsLayoutDefault = UIDevice.current.userInterfaceIdiom == .pad ? PlayerControlsLayout.medium : .small
-        static let fullScreenPlayerControlsLayoutDefault = UIDevice.current.userInterfaceIdiom == .pad ? PlayerControlsLayout.medium : .small
+        static let playerControlsLayoutDefault = Constants.isIPad ? PlayerControlsLayout.medium : .small
+        static let fullScreenPlayerControlsLayoutDefault = Constants.isIPad ? PlayerControlsLayout.medium : .small
     #elseif os(tvOS)
         static let playerControlsLayoutDefault = PlayerControlsLayout.tvRegular
         static let fullScreenPlayerControlsLayoutDefault = PlayerControlsLayout.tvRegular
@@ -179,7 +179,7 @@ extension Defaults.Keys {
     static let sd360pAVPlayerProfile = QualityProfile(id: "sd360pAVPlayerProfile", backend: .appleAVPlayer, resolution: .sd360p30, formats: [.hls, .stream], order: Array(QualityProfile.Format.allCases.indices))
 
     #if os(iOS)
-        static let qualityProfilesDefault = UIDevice.current.userInterfaceIdiom == .pad ? [
+        static let qualityProfilesDefault = Constants.isIPad ? [
             hd2160pMPVProfile,
             hd1080pMPVProfile,
             hd720pMPVProfile,

--- a/Shared/Defaults.swift
+++ b/Shared/Defaults.swift
@@ -528,7 +528,7 @@ enum FullScreenRotationSetting: String, CaseIterable, Defaults.Serializable {
             case .landscapeRight:
                 return .landscapeRight
             default:
-                return .portrait
+                return .landscapeRight
             }
         }
     #endif

--- a/Shared/Defaults.swift
+++ b/Shared/Defaults.swift
@@ -91,7 +91,6 @@ extension Defaults.Keys {
     static let enableReturnYouTubeDislike = Key<Bool>("enableReturnYouTubeDislike", default: false)
 
     #if os(iOS)
-        static let honorSystemOrientationLock = Key<Bool>("honorSystemOrientationLock", default: true)
         static let enterFullscreenInLandscape = Key<Bool>("enterFullscreenInLandscape", default: UIDevice.current.userInterfaceIdiom == .phone)
         static let rotateToLandscapeOnEnterFullScreen = Key<FullScreenRotationSetting>(
             "rotateToLandscapeOnEnterFullScreen",

--- a/Shared/Player/AppleAVPlayerView.swift
+++ b/Shared/Player/AppleAVPlayerView.swift
@@ -18,7 +18,7 @@ import SwiftUI
 
         #if os(iOS)
             func playerViewController(_: AVPlayerViewController, willBeginFullScreenPresentationWithAnimationCoordinator _: UIViewControllerTransitionCoordinator) {
-                guard rotateToLandscapeOnEnterFullScreen.isRotating && honorSystemOrientationLock ||
+                guard rotateToLandscapeOnEnterFullScreen.isRotating && honorSystemOrientationLock && player.lockedOrientation.isNil ||
                     !honorSystemOrientationLock else { return }
 
                 if PlayerModel.shared.currentVideoIsLandscape {

--- a/Shared/Player/AppleAVPlayerView.swift
+++ b/Shared/Player/AppleAVPlayerView.swift
@@ -20,10 +20,8 @@ import SwiftUI
                 guard rotateToLandscapeOnEnterFullScreen.isRotating else { return }
                 if PlayerModel.shared.currentVideoIsLandscape {
                     let delay = PlayerModel.shared.activeBackend == .appleAVPlayer && avPlayerUsesSystemControls ? 0.8 : 0
-                    // not sure why but first rotation call is ignore so doing rotate to same orientation first
                     Delay.by(delay) {
                         let orientation = OrientationTracker.shared.currentDeviceOrientation.isLandscape ? OrientationTracker.shared.currentInterfaceOrientation : self.rotateToLandscapeOnEnterFullScreen.interaceOrientation
-                        Orientation.lockOrientation(.allButUpsideDown, andRotateTo: OrientationTracker.shared.currentInterfaceOrientation)
                         Orientation.lockOrientation(.allButUpsideDown, andRotateTo: orientation)
                     }
                 }

--- a/Shared/Player/AppleAVPlayerView.swift
+++ b/Shared/Player/AppleAVPlayerView.swift
@@ -6,7 +6,6 @@ import SwiftUI
     final class AppleAVPlayerViewControllerDelegate: NSObject, AVPlayerViewControllerDelegate {
         #if os(iOS)
             @Default(.rotateToLandscapeOnEnterFullScreen) private var rotateToLandscapeOnEnterFullScreen
-            @Default(.honorSystemOrientationLock) private var honorSystemOrientationLock
             @Default(.avPlayerUsesSystemControls) private var avPlayerUsesSystemControls
         #endif
 
@@ -18,8 +17,7 @@ import SwiftUI
 
         #if os(iOS)
             func playerViewController(_: AVPlayerViewController, willBeginFullScreenPresentationWithAnimationCoordinator _: UIViewControllerTransitionCoordinator) {
-                guard rotateToLandscapeOnEnterFullScreen.isRotating && honorSystemOrientationLock && player.lockedOrientation.isNil ||
-                    !honorSystemOrientationLock else { return }
+                guard rotateToLandscapeOnEnterFullScreen.isRotating && player.lockedOrientation.isNil else { return }
 
                 if PlayerModel.shared.currentVideoIsLandscape {
                     let delay = PlayerModel.shared.activeBackend == .appleAVPlayer && avPlayerUsesSystemControls ? 0.8 : 0

--- a/Shared/Player/AppleAVPlayerView.swift
+++ b/Shared/Player/AppleAVPlayerView.swift
@@ -21,7 +21,7 @@ import SwiftUI
                 if PlayerModel.shared.currentVideoIsLandscape {
                     let delay = PlayerModel.shared.activeBackend == .appleAVPlayer && avPlayerUsesSystemControls ? 0.8 : 0
                     Delay.by(delay) {
-                        let orientation = OrientationTracker.shared.currentDeviceOrientation.isLandscape ? OrientationTracker.shared.currentInterfaceOrientation : self.rotateToLandscapeOnEnterFullScreen.interaceOrientation
+                        let orientation = OrientationTracker.shared.currentDeviceOrientation.isLandscape ? OrientationTracker.shared.currentInterfaceOrientation : self.rotateToLandscapeOnEnterFullScreen.interfaceOrientationSetting
                         Orientation.lockOrientation(.allButUpsideDown, andRotateTo: orientation)
                     }
                 }

--- a/Shared/Player/AppleAVPlayerView.swift
+++ b/Shared/Player/AppleAVPlayerView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
         #if os(iOS)
             func playerViewController(_: AVPlayerViewController, willBeginFullScreenPresentationWithAnimationCoordinator _: UIViewControllerTransitionCoordinator) {
-                guard rotateToLandscapeOnEnterFullScreen.isRotating && player.lockedOrientation.isNil else { return }
+                guard rotateToLandscapeOnEnterFullScreen.isRotating, !player.isOrientationLocked else { return }
 
                 if PlayerModel.shared.currentVideoIsLandscape {
                     let delay = PlayerModel.shared.activeBackend == .appleAVPlayer && avPlayerUsesSystemControls ? 0.8 : 0
@@ -36,7 +36,7 @@ import SwiftUI
                     }
                     if !context.isCancelled {
                         #if os(iOS)
-                            self.player.lockedOrientation = nil
+                            self.player.isOrientationLocked = false
 
                             if Constants.isIPhone {
                                 Orientation.lockOrientation(.allButUpsideDown, andRotateTo: .portrait)

--- a/Shared/Player/AppleAVPlayerView.swift
+++ b/Shared/Player/AppleAVPlayerView.swift
@@ -6,6 +6,7 @@ import SwiftUI
     final class AppleAVPlayerViewControllerDelegate: NSObject, AVPlayerViewControllerDelegate {
         #if os(iOS)
             @Default(.rotateToLandscapeOnEnterFullScreen) private var rotateToLandscapeOnEnterFullScreen
+            @Default(.honorSystemOrientationLock) private var honorSystemOrientationLock
             @Default(.avPlayerUsesSystemControls) private var avPlayerUsesSystemControls
         #endif
 
@@ -17,7 +18,9 @@ import SwiftUI
 
         #if os(iOS)
             func playerViewController(_: AVPlayerViewController, willBeginFullScreenPresentationWithAnimationCoordinator _: UIViewControllerTransitionCoordinator) {
-                guard rotateToLandscapeOnEnterFullScreen.isRotating else { return }
+                guard rotateToLandscapeOnEnterFullScreen.isRotating && honorSystemOrientationLock ||
+                    !honorSystemOrientationLock else { return }
+
                 if PlayerModel.shared.currentVideoIsLandscape {
                     let delay = PlayerModel.shared.activeBackend == .appleAVPlayer && avPlayerUsesSystemControls ? 0.8 : 0
                     Delay.by(delay) {

--- a/Shared/Player/Controls/PlayerControls.swift
+++ b/Shared/Player/Controls/PlayerControls.swift
@@ -388,11 +388,11 @@ struct PlayerControls: View {
     #if os(iOS)
         private var lockOrientationButton: some View {
             button(
-                "Lock Rotation", systemImage: player.lockOrientationImage,
-                active: player.isOrientationLocked
-            ) {
-                player.isOrientationLocked.toggle()
-            }
+                "Lock Rotation",
+                systemImage: player.lockOrientationImage,
+                active: player.isOrientationLocked,
+                action: player.toggleOrientationAction
+            )
         }
     #endif
 

--- a/Shared/Player/Controls/PlayerControls.swift
+++ b/Shared/Player/Controls/PlayerControls.swift
@@ -387,7 +387,12 @@ struct PlayerControls: View {
 
     #if os(iOS)
         private var lockOrientationButton: some View {
-            button("Lock Rotation", systemImage: player.lockOrientationImage, active: !player.lockedOrientation.isNil, action: player.lockOrientationAction)
+            button(
+                "Lock Rotation", systemImage: player.lockOrientationImage,
+                active: player.isOrientationLocked
+            ) {
+                player.isOrientationLocked.toggle()
+            }
         }
     #endif
 

--- a/Shared/Player/Controls/PlayerControlsLayout.swift
+++ b/Shared/Player/Controls/PlayerControlsLayout.swift
@@ -13,22 +13,14 @@ enum PlayerControlsLayout: String, CaseIterable, Defaults.Serializable {
     case smaller
 
     var available: Bool {
-        var isATV = false
-        var isIPad = false
-        #if os(tvOS)
-            isATV = true
-        #endif
-        #if os(iOS)
-            isIPad = UIDevice.current.userInterfaceIdiom == .pad
-        #endif
         switch self {
         case .tvRegular:
-            return isATV
+            return Constants.isAppleTV
         case .veryLarge:
             #if os(macOS)
                 return true
             #else
-                return isIPad
+                return Constants.isIPad
             #endif
         case .large:
             return true

--- a/Shared/Player/PlayerBackendView.swift
+++ b/Shared/Player/PlayerBackendView.swift
@@ -68,14 +68,14 @@ struct PlayerBackendView: View {
         var controlsTopPadding: Double {
             guard player.playingFullScreen else { return 0 }
 
-            if UIDevice.current.userInterfaceIdiom != .pad {
+            if !Constants.isIPad {
                 return verticalSizeClass == .compact ? safeAreaModel.safeArea.top : 0
             }
             return safeAreaModel.safeArea.top.isZero ? safeAreaModel.safeArea.bottom : safeAreaModel.safeArea.top
         }
 
         var controlsBottomPadding: Double {
-            if UIDevice.current.userInterfaceIdiom != .pad {
+            if !Constants.isIPad {
                 return player.playingFullScreen || verticalSizeClass == .compact ? safeAreaModel.safeArea.bottom : 0
             }
             return player.playingFullScreen ? safeAreaModel.safeArea.bottom : 0

--- a/Shared/Player/PlayerDragGesture.swift
+++ b/Shared/Player/PlayerDragGesture.swift
@@ -90,7 +90,7 @@ extension VideoPlayerView {
            player.playingFullScreen
         {
             #if os(iOS)
-                player.lockedOrientation = nil
+                player.isOrientationLocked = false
             #endif
             player.exitFullScreen(showControls: false)
             viewDragOffset = 0

--- a/Shared/Player/Video Details/VideoActions.swift
+++ b/Shared/Player/Video Details/VideoActions.swift
@@ -154,7 +154,12 @@ struct VideoActions: View {
                     actionButton("PiP", systemImage: player.pipImage, action: player.togglePiPAction)
                 #if os(iOS)
                     case .lockOrientation:
-                        actionButton("Lock", systemImage: player.lockOrientationImage, active: player.lockedOrientation != nil, action: player.lockOrientationAction)
+                        actionButton(
+                            "Lock", systemImage: player.lockOrientationImage,
+                            active: player.isOrientationLocked
+                        ) {
+                            player.isOrientationLocked.toggle()
+                        }
                 #endif
                 case .restart:
                     actionButton("Replay", systemImage: "backward.end.fill", action: player.replayAction)

--- a/Shared/Player/Video Details/VideoActions.swift
+++ b/Shared/Player/Video Details/VideoActions.swift
@@ -155,11 +155,11 @@ struct VideoActions: View {
                 #if os(iOS)
                     case .lockOrientation:
                         actionButton(
-                            "Lock", systemImage: player.lockOrientationImage,
-                            active: player.isOrientationLocked
-                        ) {
-                            player.isOrientationLocked.toggle()
-                        }
+                            "Lock",
+                            systemImage: player.lockOrientationImage,
+                            active: player.isOrientationLocked,
+                            action: player.toggleOrientationAction
+                        )
                 #endif
                 case .restart:
                     actionButton("Replay", systemImage: "backward.end.fill", action: player.replayAction)

--- a/Shared/Settings/BrowsingSettings.swift
+++ b/Shared/Settings/BrowsingSettings.swift
@@ -164,7 +164,7 @@ struct BrowsingSettings: View {
                 Toggle("Lock portrait mode", isOn: $lockPortraitWhenBrowsing)
                     .onChange(of: lockPortraitWhenBrowsing) { lock in
                         if lock {
-                            Orientation.lockOrientation(.portrait, andRotateTo: .portrait)
+                            Orientation.lockOrientation(.all, andRotateTo: .portrait)
                         } else {
                             Orientation.lockOrientation(.allButUpsideDown)
                         }

--- a/Shared/Settings/BrowsingSettings.swift
+++ b/Shared/Settings/BrowsingSettings.swift
@@ -160,15 +160,16 @@ struct BrowsingSettings: View {
             #endif
             #if os(iOS)
                 Toggle("Show Documents", isOn: $showDocuments)
-
-                Toggle("Lock portrait mode", isOn: $lockPortraitWhenBrowsing)
-                    .onChange(of: lockPortraitWhenBrowsing) { lock in
-                        if lock {
-                            Orientation.lockOrientation(.all, andRotateTo: .portrait)
-                        } else {
-                            Orientation.lockOrientation(.allButUpsideDown)
+                if Constants.isIPad {
+                    Toggle("Lock portrait mode", isOn: $lockPortraitWhenBrowsing)
+                        .onChange(of: lockPortraitWhenBrowsing) { lock in
+                            if lock {
+                                Orientation.lockOrientation(.allButUpsideDown, andRotateTo: .portrait)
+                            } else {
+                                Orientation.lockOrientation(.all, andRotateTo: OrientationTracker.shared.currentInterfaceOrientation)
+                            }
                         }
-                    }
+                }
             #endif
 
             if !accounts.isEmpty {

--- a/Shared/Settings/PlayerSettings.swift
+++ b/Shared/Settings/PlayerSettings.swift
@@ -45,12 +45,6 @@ struct PlayerSettings: View {
 
     @ObservedObject private var accounts = AccountsModel.shared
 
-    #if os(iOS)
-        private var idiom: UIUserInterfaceIdiom {
-            UIDevice.current.userInterfaceIdiom
-        }
-    #endif
-
     #if os(tvOS)
         @State private var isShowingDefaultLanguagePicker = false
         @State private var isShowingFallbackLanguagePicker = false
@@ -162,7 +156,7 @@ struct PlayerSettings: View {
 
             let interface = Section(header: SettingsHeader(text: "Interface".localized())) {
                 #if os(iOS)
-                    if idiom == .pad {
+                    if Constants.isIPad {
                         sidebarPicker
                     }
                 #endif
@@ -189,14 +183,14 @@ struct PlayerSettings: View {
             #elseif os(macOS)
                 interface
             #elseif os(iOS)
-                if idiom == .pad || !accounts.isEmpty {
+                if Constants.isIPad || !accounts.isEmpty {
                     interface
                 }
             #endif
 
             #if os(iOS)
                 Section(header: SettingsHeader(text: "Orientation".localized())) {
-                    if idiom == .pad {
+                    if Constants.isIPad {
                         enterFullscreenInLandscapeToggle
                     }
                     rotateToLandscapeOnEnterFullScreenPicker

--- a/Shared/Settings/PlayerSettings.swift
+++ b/Shared/Settings/PlayerSettings.swift
@@ -302,7 +302,7 @@ struct PlayerSettings: View {
 
     #if os(iOS)
         private var honorSystemOrientationLockToggle: some View {
-            Toggle("Honor orientation lock", isOn: $honorSystemOrientationLock)
+            Toggle("Follow device orientation lock", isOn: $honorSystemOrientationLock)
                 .disabled(!enterFullscreenInLandscape)
         }
 
@@ -311,7 +311,7 @@ struct PlayerSettings: View {
         }
 
         private var rotateToLandscapeOnEnterFullScreenPicker: some View {
-            Picker("Rotate when entering fullscreen on landscape video", selection: $rotateToLandscapeOnEnterFullScreen) {
+            Picker("Fullscreen rotation", selection: $rotateToLandscapeOnEnterFullScreen) {
                 Text("Landscape left").tag(FullScreenRotationSetting.landscapeLeft)
                 Text("Landscape right").tag(FullScreenRotationSetting.landscapeRight)
                 Text("No rotation").tag(FullScreenRotationSetting.disabled)

--- a/Shared/Settings/PlayerSettings.swift
+++ b/Shared/Settings/PlayerSettings.swift
@@ -307,7 +307,6 @@ struct PlayerSettings: View {
             Picker("Fullscreen rotation", selection: $rotateToLandscapeOnEnterFullScreen) {
                 Text("Landscape left").tag(FullScreenRotationSetting.landscapeLeft)
                 Text("Landscape right").tag(FullScreenRotationSetting.landscapeRight)
-                Text("No rotation").tag(FullScreenRotationSetting.disabled)
             }
             .modifier(SettingsPickerModifier())
         }

--- a/Shared/Settings/PlayerSettings.swift
+++ b/Shared/Settings/PlayerSettings.swift
@@ -16,7 +16,6 @@ struct PlayerSettings: View {
     @Default(.pauseOnHidingPlayer) private var pauseOnHidingPlayer
     @Default(.closeVideoOnEOF) private var closeVideoOnEOF
     #if os(iOS)
-        @Default(.honorSystemOrientationLock) private var honorSystemOrientationLock
         @Default(.enterFullscreenInLandscape) private var enterFullscreenInLandscape
         @Default(.rotateToLandscapeOnEnterFullScreen) private var rotateToLandscapeOnEnterFullScreen
     #endif
@@ -200,7 +199,6 @@ struct PlayerSettings: View {
                     if idiom == .pad {
                         enterFullscreenInLandscapeToggle
                     }
-                    honorSystemOrientationLockToggle
                     rotateToLandscapeOnEnterFullScreenPicker
                 }
             #endif
@@ -301,11 +299,6 @@ struct PlayerSettings: View {
     #endif
 
     #if os(iOS)
-        private var honorSystemOrientationLockToggle: some View {
-            Toggle("Follow device orientation lock", isOn: $honorSystemOrientationLock)
-                .disabled(!enterFullscreenInLandscape)
-        }
-
         private var enterFullscreenInLandscapeToggle: some View {
             Toggle("Enter fullscreen in landscape", isOn: $enterFullscreenInLandscape)
         }

--- a/Shared/Settings/PlayerSettings.swift
+++ b/Shared/Settings/PlayerSettings.swift
@@ -312,8 +312,8 @@ struct PlayerSettings: View {
 
         private var rotateToLandscapeOnEnterFullScreenPicker: some View {
             Picker("Rotate when entering fullscreen on landscape video", selection: $rotateToLandscapeOnEnterFullScreen) {
-                Text("Landscape left").tag(FullScreenRotationSetting.landscapeRight)
-                Text("Landscape right").tag(FullScreenRotationSetting.landscapeLeft)
+                Text("Landscape left").tag(FullScreenRotationSetting.landscapeLeft)
+                Text("Landscape right").tag(FullScreenRotationSetting.landscapeRight)
                 Text("No rotation").tag(FullScreenRotationSetting.disabled)
             }
             .modifier(SettingsPickerModifier())

--- a/Shared/YatteeApp.swift
+++ b/Shared/YatteeApp.swift
@@ -151,6 +151,32 @@ struct YatteeApp: App {
         configured = true
 
         DispatchQueue.main.async {
+            #if os(iOS)
+                DispatchQueue.main.async {
+                    if Defaults[.lockPortraitWhenBrowsing] {
+                        Orientation.lockOrientation(.all, andRotateTo: .portrait)
+                    }
+                }
+            #endif
+
+            DispatchQueue.global(qos: .userInitiated).async {
+                if !Defaults[.saveRecents] {
+                    recents.clear()
+                }
+            }
+
+            DispatchQueue.global(qos: .userInitiated).async {
+                URLBookmarkModel.shared.refreshAll()
+            }
+
+            DispatchQueue.global(qos: .userInitiated).async {
+                self.migrateHomeHistoryItems()
+            }
+
+            DispatchQueue.global(qos: .userInitiated).async {
+                self.migrateQualityProfiles()
+            }
+
             #if DEBUG
                 SiestaLog.Category.enabled = .common
             #endif
@@ -197,28 +223,8 @@ struct YatteeApp: App {
                 player.presentingPlayer = false
             }
 
-            #if os(iOS)
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                    if Defaults[.lockPortraitWhenBrowsing] {
-                        Orientation.lockOrientation(.all, andRotateTo: .portrait)
-                    }
-                }
-            #endif
-
             // Initialize UserAgentManager
             _ = UserAgentManager.shared
-
-            DispatchQueue.global(qos: .userInitiated).async {
-                URLBookmarkModel.shared.refreshAll()
-            }
-
-            DispatchQueue.global(qos: .userInitiated).async {
-                self.migrateHomeHistoryItems()
-            }
-
-            DispatchQueue.global(qos: .userInitiated).async {
-                self.migrateQualityProfiles()
-            }
         }
     }
 

--- a/Shared/YatteeApp.swift
+++ b/Shared/YatteeApp.swift
@@ -174,12 +174,6 @@ struct YatteeApp: App {
                 player.restoreQueue()
             }
 
-            DispatchQueue.global(qos: .userInitiated).async {
-                if !Defaults[.saveRecents] {
-                    recents.clear()
-                }
-            }
-
             let startupSection = Defaults[.startupSection]
             var section: TabSelection? = startupSection.tabSelection
 

--- a/Shared/YatteeApp.swift
+++ b/Shared/YatteeApp.swift
@@ -151,14 +151,6 @@ struct YatteeApp: App {
         configured = true
 
         DispatchQueue.main.async {
-            #if os(iOS)
-                DispatchQueue.main.async {
-                    if Defaults[.lockPortraitWhenBrowsing] {
-                        Orientation.lockOrientation(.all, andRotateTo: .portrait)
-                    }
-                }
-            #endif
-
             DispatchQueue.global(qos: .userInitiated).async {
                 if !Defaults[.saveRecents] {
                     recents.clear()

--- a/Shared/YatteeApp.swift
+++ b/Shared/YatteeApp.swift
@@ -169,6 +169,10 @@ struct YatteeApp: App {
                 self.migrateQualityProfiles()
             }
 
+            DispatchQueue.global(qos: .userInitiated).async {
+                self.migrateLockPortrait()
+            }
+
             #if DEBUG
                 SiestaLog.Category.enabled = .common
             #endif
@@ -242,6 +246,16 @@ struct YatteeApp: App {
             var updatedProfile = profile
             updatedProfile.order = Array(QualityProfile.Format.allCases.indices)
             QualityProfilesModel.shared.update(profile, updatedProfile)
+        }
+    }
+
+    func migrateLockPortrait() {
+        if Constants.isIPhone {
+            Defaults[.lockPortraitWhenBrowsing] = true
+            Defaults[.enterFullscreenInLandscape] = true
+            if Defaults[.rotateToLandscapeOnEnterFullScreen] == .disabled {
+                Defaults[.rotateToLandscapeOnEnterFullScreen] = .landscapeRight
+            }
         }
     }
 

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -11,12 +11,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // Determine supported interface orientations
     func application(_: UIApplication, supportedInterfaceOrientationsFor _: UIWindow?) -> UIInterfaceOrientationMask {
-        // If portrait lock is enabled, enforce portrait orientation
-        if Defaults[.lockPortraitWhenBrowsing], !Defaults[.enterFullscreenInLandscape] {
-            return .portrait
-        }
-
-        // Use the orientation lock from the instance
         return orientationLock
     }
 

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -12,7 +12,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     // Determine supported interface orientations
     func application(_: UIApplication, supportedInterfaceOrientationsFor _: UIWindow?) -> UIInterfaceOrientationMask {
         // If portrait lock is enabled, enforce portrait orientation
-        if Defaults[.lockPortraitWhenBrowsing] {
+        if Defaults[.lockPortraitWhenBrowsing], !Defaults[.enterFullscreenInLandscape] {
             return .portrait
         }
 

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -23,6 +23,9 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Start orientation tracking
         OrientationTracker.shared.startDeviceOrientationTracking()
+
+        // Check and apply orientation lock if necessary
+        applyInitialOrientationLock()
         #endif
 
         return true
@@ -36,5 +39,15 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
             return true
         }
         return false
+    }
+
+    // Function to apply initial orientation lock based on Defaults
+    private func applyInitialOrientationLock() {
+        if Defaults[.lockPortraitWhenBrowsing] {
+            orientationLock = .portrait
+            Orientation.lockOrientation(.portrait, andRotateTo: .portrait)
+        } else {
+            orientationLock = .all
+        }
     }
 }

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -1,26 +1,42 @@
+import Defaults
 import Foundation
 import UIKit
 
 final class AppDelegate: UIResponder, UIApplicationDelegate {
-    var orientationLock = UIInterfaceOrientationMask.all
+    // Holds the current orientation lock setting
+    var orientationLock: UIInterfaceOrientationMask = .all
 
+    // Singleton instance for access
     private(set) static var instance: AppDelegate!
 
+    // Determine supported interface orientations
     func application(_: UIApplication, supportedInterfaceOrientationsFor _: UIWindow?) -> UIInterfaceOrientationMask {
-        orientationLock
+        // If portrait lock is enabled, enforce portrait orientation
+        if Defaults[.lockPortraitWhenBrowsing] {
+            return .portrait
+        }
+
+        // Use the orientation lock from the instance
+        return orientationLock
     }
 
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool { // swiftlint:disable:this discouraged_optional_collection
         Self.instance = self
-        #if os(iOS)
-            UIViewController.swizzleHomeIndicatorProperty()
 
-            OrientationTracker.shared.startDeviceOrientationTracking()
+        #if os(iOS)
+        // Perform any necessary swizzling or setup
+        UIViewController.swizzleHomeIndicatorProperty()
+
+        // Start orientation tracking
+        OrientationTracker.shared.startDeviceOrientationTracking()
         #endif
+
         return true
     }
 
+    // Handle URLs opened by the app
     func application(_: UIApplication, open url: URL, options _: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        // Handle custom URL scheme
         if url.scheme == "yattee" {
             OpenURLHandler(navigationStyle: Constants.defaultNavigationStyle).handle(url)
             return true

--- a/iOS/Orientation.swift
+++ b/iOS/Orientation.swift
@@ -16,8 +16,7 @@ enum Orientation {
     }
 
     static func lockOrientation(_ orientation: UIInterfaceOrientationMask, andRotateTo rotateOrientation: UIInterfaceOrientation? = nil) {
-        if Defaults[.lockPortraitWhenBrowsing] {
-            // Lock orientation to portrait when browsing
+        if Defaults[.lockPortraitWhenBrowsing], !Defaults[.enterFullscreenInLandscape] {
             lockOrientation(.portrait)
             return
         }

--- a/iOS/Orientation.swift
+++ b/iOS/Orientation.swift
@@ -16,7 +16,7 @@ enum Orientation {
     }
 
     static func lockOrientation(_ orientation: UIInterfaceOrientationMask, andRotateTo rotateOrientation: UIInterfaceOrientation? = nil) {
-        if Defaults[.lockPortraitWhenBrowsing], !Defaults[.enterFullscreenInLandscape] {
+        if Defaults[.lockPortraitWhenBrowsing], !PlayerModel.shared.presentingPlayer {
             lockOrientation(.portrait)
             return
         }

--- a/iOS/OrientationModel.swift
+++ b/iOS/OrientationModel.swift
@@ -60,7 +60,6 @@ final class OrientationModel {
     private func shouldEnterFullScreen(for orientation: UIInterfaceOrientation) -> Bool {
         return orientation.isLandscape &&
             Defaults[.enterFullscreenInLandscape] &&
-            !Defaults[.honorSystemOrientationLock] &&
             !player.playingFullScreen &&
             !player.currentItem.isNil &&
             (player.lockedOrientation.isNil || player.lockedOrientation!.contains(.landscape)) &&
@@ -69,11 +68,6 @@ final class OrientationModel {
     }
 
     private func handleOrientationChange() {
-        // Early exit if system lock is honored
-        if Defaults[.honorSystemOrientationLock] {
-            return
-        }
-
         if Defaults[.lockPortraitWhenBrowsing] {
             Orientation.lockOrientation(.portrait)
             return

--- a/iOS/OrientationModel.swift
+++ b/iOS/OrientationModel.swift
@@ -67,10 +67,8 @@ final class OrientationModel {
                         if orientation.isLandscape {
                             self.player.controls.presentingControls = false
                             self.player.enterFullScreen(showControls: false)
-                            Orientation.lockOrientation(OrientationTracker.shared.currentInterfaceOrientationMask, andRotateTo: orientation)
                         } else {
                             self.player.exitFullScreen(showControls: false)
-                            Orientation.lockOrientation(.allButUpsideDown, andRotateTo: .portrait)
                         }
                     }
                 }

--- a/iOS/OrientationModel.swift
+++ b/iOS/OrientationModel.swift
@@ -6,7 +6,7 @@ import SwiftUI
 
 final class OrientationModel {
     static let shared = OrientationModel()
-    var logger = Logger(label: "stream.yattee.orientation")
+    var logger = Logger(label: "stream.yattee.orientation.model")
 
     private var lastOrientation: UIInterfaceOrientation?
     private var orientationDebouncer = Debouncer(.milliseconds(300))

--- a/iOS/OrientationModel.swift
+++ b/iOS/OrientationModel.swift
@@ -34,7 +34,9 @@ final class OrientationModel {
             object: nil,
             queue: .main
         ) { _ in
-            self.handleOrientationChange()
+            if Defaults[.lockPortraitWhenBrowsing] || self.player.presentingPlayer {
+                self.handleOrientationChange()
+            }
         }
     }
 
@@ -70,7 +72,7 @@ final class OrientationModel {
     }
 
     private func handleOrientationChange() {
-        if Defaults[.lockPortraitWhenBrowsing] {
+        if Defaults[.lockPortraitWhenBrowsing], !player.presentingPlayer {
             logger.info("Locking orientation to portrait due to browsing setting")
             Orientation.lockOrientation(.portrait)
             return

--- a/iOS/OrientationModel.swift
+++ b/iOS/OrientationModel.swift
@@ -54,7 +54,7 @@ final class OrientationModel {
             Orientation.lockOrientation(.portrait)
         } else {
             logger.info("Locking orientation to all but upside down and rotating to \(rotateOrientation)")
-            let mask: UIInterfaceOrientationMask = UIDevice.current.userInterfaceIdiom == .pad ? .all : .allButUpsideDown
+            let mask: UIInterfaceOrientationMask = Constants.isIPad ? .all : .allButUpsideDown
             Orientation.lockOrientation(mask, andRotateTo: rotateOrientation)
         }
     }

--- a/iOS/OrientationModel.swift
+++ b/iOS/OrientationModel.swift
@@ -34,7 +34,8 @@ final class OrientationModel {
             object: nil,
             queue: .main
         ) { _ in
-            if Defaults[.lockPortraitWhenBrowsing] || self.player.presentingPlayer {
+            if !Defaults[.lockPortraitWhenBrowsing] || (self.player.presentingPlayer && !self.player.isOrientationLocked) {
+                self.logger.info("Handle orientation change")
                 self.handleOrientationChange()
             }
         }
@@ -66,7 +67,7 @@ final class OrientationModel {
             Defaults[.enterFullscreenInLandscape] &&
             !player.playingFullScreen &&
             !player.currentItem.isNil &&
-            (player.lockedOrientation.isNil || player.lockedOrientation!.contains(.landscape)) &&
+            !player.isOrientationLocked &&
             !player.playingInPictureInPicture &&
             player.presentingPlayer
     }
@@ -78,7 +79,7 @@ final class OrientationModel {
             return
         }
 
-        guard player.presentingPlayer, !player.playingInPictureInPicture, player.lockedOrientation.isNil else {
+        guard player.presentingPlayer, !player.playingInPictureInPicture, !player.isOrientationLocked else {
             return
         }
 

--- a/iOS/OrientationTracker.swift
+++ b/iOS/OrientationTracker.swift
@@ -106,7 +106,7 @@ public class OrientationTracker {
             return .portrait
         }
 
-        if UIDevice.current.userInterfaceIdiom == .pad && accelerometerData.acceleration.y >= threshold {
+        if Constants.isIPad && accelerometerData.acceleration.y >= threshold {
             // iPad specific upside down portrait
             return .portraitUpsideDown
         }

--- a/iOS/OrientationTracker.swift
+++ b/iOS/OrientationTracker.swift
@@ -89,7 +89,7 @@ public class OrientationTracker {
 
     /// Determines the device orientation based on accelerometer data.
     private func deviceOrientation(for accelerometerData: CMAccelerometerData) -> UIDeviceOrientation {
-        let threshold = 0.75
+        let threshold = 0.55
 
         if accelerometerData.acceleration.x >= threshold {
             // Landscape left

--- a/iOS/OrientationTracker.swift
+++ b/iOS/OrientationTracker.swift
@@ -1,8 +1,11 @@
 import CoreMotion
+import Logging
 import UIKit
 
 /// Singleton class to track device orientation changes using the accelerometer.
 public class OrientationTracker {
+    var logger = Logger(label: "stream.yattee.orientation.tracker")
+
     public static let shared = OrientationTracker()
 
     public static let deviceOrientationChangedNotification = NSNotification.Name("DeviceOrientationChangedNotification")
@@ -70,7 +73,7 @@ public class OrientationTracker {
         motionManager.startAccelerometerUpdates(to: queue) { [weak self] accelerometerData, error in
             guard let self else { return }
             guard error == nil, let accelerometerData else {
-                // Consider logging the error
+                self.logger.info("Error: \(String(describing: error))")
                 return
             }
 

--- a/iOS/OrientationTracker.swift
+++ b/iOS/OrientationTracker.swift
@@ -1,37 +1,46 @@
 import CoreMotion
 import UIKit
 
+/// Singleton class to track device orientation changes using the accelerometer.
 public class OrientationTracker {
     public static let shared = OrientationTracker()
 
     public static let deviceOrientationChangedNotification = NSNotification.Name("DeviceOrientationChangedNotification")
 
-    public var currentDeviceOrientation: UIDeviceOrientation = .portrait
+    /// Current device orientation.
+    public private(set) var currentDeviceOrientation: UIDeviceOrientation = .portrait
 
+    /// Current interface orientation derived from the device orientation.
     public var currentInterfaceOrientation: UIInterfaceOrientation {
         switch currentDeviceOrientation {
         case .landscapeLeft:
             return .landscapeLeft
         case .landscapeRight:
             return .landscapeRight
+        case .portraitUpsideDown:
+            return .portraitUpsideDown
         default:
             return .portrait
         }
     }
 
+    /// Current interface orientation mask derived from the device orientation.
     public var currentInterfaceOrientationMask: UIInterfaceOrientationMask {
         switch currentInterfaceOrientation {
         case .landscapeLeft:
             return .landscapeLeft
         case .landscapeRight:
             return .landscapeRight
+        case .portraitUpsideDown:
+            return .portraitUpsideDown
         default:
             return .portrait
         }
     }
 
+    /// Affine transform for the current device orientation.
     public var affineTransform: CGAffineTransform {
-        var angleRadians: Double
+        let angleRadians: Double
         switch currentDeviceOrientation {
         case .portrait:
             angleRadians = 0
@@ -56,41 +65,53 @@ public class OrientationTracker {
         queue = OperationQueue()
     }
 
+    /// Starts tracking device orientation changes.
     public func startDeviceOrientationTracking() {
-        motionManager.startAccelerometerUpdates(to: queue) { accelerometerData, error in
-            guard error == nil else { return }
-            guard let accelerometerData else { return }
+        motionManager.startAccelerometerUpdates(to: queue) { [weak self] accelerometerData, error in
+            guard let self else { return }
+            guard error == nil, let accelerometerData else {
+                // Consider logging the error
+                return
+            }
 
-            let newDeviceOrientation = self.deviceOrientation(forAccelerometerData: accelerometerData)
+            let newDeviceOrientation = self.deviceOrientation(for: accelerometerData)
             guard newDeviceOrientation != self.currentDeviceOrientation else { return }
-            self.currentDeviceOrientation = newDeviceOrientation
 
-            NotificationCenter.default.post(name: Self.deviceOrientationChangedNotification,
-                                            object: nil,
-                                            userInfo: nil)
+            self.currentDeviceOrientation = newDeviceOrientation
+            NotificationCenter.default.post(name: Self.deviceOrientationChangedNotification, object: nil)
         }
     }
 
+    /// Stops tracking device orientation changes.
     public func stopDeviceOrientationTracking() {
         motionManager.stopAccelerometerUpdates()
     }
 
-    private func deviceOrientation(forAccelerometerData accelerometerData: CMAccelerometerData) -> UIDeviceOrientation {
+    /// Determines the device orientation based on accelerometer data.
+    private func deviceOrientation(for accelerometerData: CMAccelerometerData) -> UIDeviceOrientation {
         let threshold = 0.55
+
         if accelerometerData.acceleration.x >= threshold {
+            // Landscape left
             return .landscapeLeft
         }
+
         if accelerometerData.acceleration.x <= -threshold {
+            // Landscape right
             return .landscapeRight
         }
+
         if accelerometerData.acceleration.y <= -threshold {
+            // Portrait
             return .portrait
         }
 
         if UIDevice.current.userInterfaceIdiom == .pad && accelerometerData.acceleration.y >= threshold {
+            // iPad specific upside down portrait
             return .portraitUpsideDown
         }
 
+        // Default to the current device orientation if none of the conditions match
         return currentDeviceOrientation
     }
 }

--- a/iOS/OrientationTracker.swift
+++ b/iOS/OrientationTracker.swift
@@ -89,7 +89,7 @@ public class OrientationTracker {
 
     /// Determines the device orientation based on accelerometer data.
     private func deviceOrientation(for accelerometerData: CMAccelerometerData) -> UIDeviceOrientation {
-        let threshold = 0.55
+        let threshold = 0.75
 
         if accelerometerData.acceleration.x >= threshold {
             // Landscape left


### PR DESCRIPTION
The orientationdebouncer was always firing on rotation changes, interfering with lockOrientation calls from the player. This resulted in multiple rotations to the same orientation. Visible for the user were multiple changes in the video size when rotating the device.

Moreover, when Browser was locked to portrait, the very first landscape rotation did not register and needed to be called twice.

Should also fix #499 