### PR TITLE
call correct class of  SDImageAWebPCoder

### DIFF
--- a/Shared/YatteeApp.swift
+++ b/Shared/YatteeApp.swift
@@ -153,7 +153,7 @@ struct YatteeApp: App {
         #if DEBUG
             SiestaLog.Category.enabled = .common
         #endif
-        SDImageCodersManager.shared.addCoder(SDImageWebPCoder.shared)
+        SDImageCodersManager.shared.addCoder(SDImageAWebPCoder.shared)
         SDWebImageManager.defaultImageCache = PINCache(name: "stream.yattee.app")
 
         if !Defaults[.lastAccountIsPublic] {


### PR DESCRIPTION
We added a non-existing class and this caused a lot of severe hangs.