### PR TITLE
 HLS: set target bitrate / AVPlayer: higher resolution

### DIFF
--- a/Model/Applications/InvidiousAPI.swift
+++ b/Model/Applications/InvidiousAPI.swift
@@ -654,7 +654,8 @@ final class InvidiousAPI: Service, ObservableObject, VideosAPI {
                 resolution: Stream.Resolution.from(resolution: videoStream["resolution"].stringValue),
                 kind: .adaptive,
                 encoding: videoStream["encoding"].string,
-                videoFormat: videoStream["type"].string
+                videoFormat: videoStream["type"].string,
+                bitrate: videoStream["bitrate"].int
             )
         }
     }

--- a/Model/Applications/PipedAPI.swift
+++ b/Model/Applications/PipedAPI.swift
@@ -687,6 +687,7 @@ final class PipedAPI: Service, ObservableObject, VideosAPI {
             let fps = qualityComponents.count > 1 ? Int(qualityComponents[1]) : 30
             let resolution = Stream.Resolution.from(resolution: quality, fps: fps)
             let videoFormat = videoStream.dictionaryValue["format"]?.string
+            let bitrate = videoStream.dictionaryValue["bitrate"]?.int
 
             if videoOnly {
                 streams.append(
@@ -696,7 +697,8 @@ final class PipedAPI: Service, ObservableObject, VideosAPI {
                         videoAsset: videoAsset,
                         resolution: resolution,
                         kind: .adaptive,
-                        videoFormat: videoFormat
+                        videoFormat: videoFormat,
+                        bitrate: bitrate
                     )
                 )
             } else {

--- a/Model/Player/Backends/AVPlayerBackend.swift
+++ b/Model/Player/Backends/AVPlayerBackend.swift
@@ -298,6 +298,11 @@ final class AVPlayerBackend: PlayerBackend {
         removeItemDidPlayToEndTimeObserver()
 
         model.playerItem = playerItem(stream)
+
+        if stream.isHLS {
+            model.playerItem?.preferredPeakBitRate = Double(model.qualityProfile?.resolution.value.bitrate ?? 0)
+        }
+
         guard model.playerItem != nil else {
             return
         }

--- a/Model/Player/Backends/AVPlayerBackend.swift
+++ b/Model/Player/Backends/AVPlayerBackend.swift
@@ -116,16 +116,6 @@ final class AVPlayerBackend: PlayerBackend {
         #endif
     }
 
-    func bestPlayable(_ streams: [Stream], maxResolution: ResolutionSetting) -> Stream? {
-        let sortedByResolution = streams
-            .filter { ($0.kind == .adaptive || $0.kind == .stream) && $0.resolution <= maxResolution.value }
-            .sorted { $0.resolution > $1.resolution }
-
-        return streams.first { $0.kind == .hls } ??
-            sortedByResolution.first { $0.kind == .stream } ??
-            sortedByResolution.first
-    }
-
     func canPlay(_ stream: Stream) -> Bool {
         stream.kind == .hls || stream.kind == .stream || (stream.kind == .adaptive && stream.format == .mp4)
     }

--- a/Model/Player/Backends/MPVBackend.swift
+++ b/Model/Player/Backends/MPVBackend.swift
@@ -286,7 +286,7 @@ final class MPVBackend: PlayerBackend {
                         }
                     }
 
-                    client.loadFile(url, sub: captions?.url, time: time, forceSeekable: stream.kind == .hls) { [weak self] _ in
+                    client.loadFile(url, bitrate: stream.bitrate, kind: stream.kind, sub: captions?.url, time: time, forceSeekable: stream.kind == .hls) { [weak self] _ in
                         self?.isLoadingVideo = true
                     }
                 } else {
@@ -298,7 +298,7 @@ final class MPVBackend: PlayerBackend {
                     let fileToLoad = self.model.musicMode ? stream.audioAsset.url : stream.videoAsset.url
                     let audioTrack = self.model.musicMode ? nil : stream.audioAsset.url
 
-                    client.loadFile(fileToLoad, audio: audioTrack, sub: captions?.url, time: time, forceSeekable: stream.kind == .hls) { [weak self] _ in
+                    client.loadFile(fileToLoad, audio: audioTrack, bitrate: stream.bitrate, kind: stream.kind, sub: captions?.url, time: time, forceSeekable: stream.kind == .hls) { [weak self] _ in
                         self?.isLoadingVideo = true
                         self?.pause()
                     }

--- a/Model/Player/Backends/MPVBackend.swift
+++ b/Model/Player/Backends/MPVBackend.swift
@@ -201,29 +201,6 @@ final class MPVBackend: PlayerBackend {
 
     typealias AreInIncreasingOrder = (Stream, Stream) -> Bool
 
-    func bestPlayable(_ streams: [Stream], maxResolution: ResolutionSetting) -> Stream? {
-        streams
-            .filter { $0.kind != .hls && $0.resolution <= maxResolution.value }
-            .max { lhs, rhs in
-                let predicates: [AreInIncreasingOrder] = [
-                    { $0.resolution < $1.resolution },
-                    { $0.format > $1.format }
-                ]
-
-                for predicate in predicates {
-                    if !predicate(lhs, rhs), !predicate(rhs, lhs) {
-                        continue
-                    }
-
-                    return predicate(lhs, rhs)
-                }
-
-                return false
-            } ??
-            streams.first { $0.kind == .hls } ??
-            streams.first
-    }
-
     func canPlay(_ stream: Stream) -> Bool {
         stream.resolution != .unknown && stream.format != .av1
     }

--- a/Model/Player/Backends/MPVClient.swift
+++ b/Model/Player/Backends/MPVClient.swift
@@ -128,6 +128,8 @@ final class MPVClient: ObservableObject {
     func loadFile(
         _ url: URL,
         audio: URL? = nil,
+        bitrate: Int? = nil,
+        kind: Stream.Kind,
         sub: URL? = nil,
         time: CMTime? = nil,
         forceSeekable: Bool = false,
@@ -158,6 +160,10 @@ final class MPVClient: ObservableObject {
 
         if !options.isEmpty {
             args.append(options.joined(separator: ","))
+        }
+
+        if kind == .hls, bitrate != 0 {
+            checkError(mpv_set_option_string(mpv, "hls-bitrate", String(describing: bitrate)))
         }
 
         command("loadfile", args: args, returnValueCallback: completionHandler)

--- a/Model/Player/Backends/PlayerBackend.swift
+++ b/Model/Player/Backends/PlayerBackend.swift
@@ -137,11 +137,17 @@ extension PlayerBackend {
         // find max resolution from non HLS streams
         let bestResolution = nonHLSStreams
             .filter { $0.resolution <= maxResolution.value }
-            .max { $0.resolution < $1.resolution }?.resolution
+            .max { $0.resolution < $1.resolution }
+
+        // finde max bitrate from non HLS streams
+        let bestBitrate = nonHLSStreams
+            .filter { $0.resolution <= maxResolution.value }
+            .max { $0.bitrate ?? 0 < $1.bitrate ?? 0 }
 
         return streams.map { stream in
             if stream.kind == .hls {
-                stream.resolution = bestResolution ?? maxResolution.value
+                stream.resolution = bestResolution?.resolution ?? maxResolution.value
+                stream.bitrate = bestBitrate?.bitrate ?? (bestResolution?.resolution.bitrate ?? maxResolution.value.bitrate)
                 stream.format = .hls
             } else if stream.kind == .stream {
                 stream.format = .stream

--- a/Model/Player/Backends/PlayerBackend.swift
+++ b/Model/Player/Backends/PlayerBackend.swift
@@ -131,9 +131,17 @@ extension PlayerBackend {
     }
 
     func bestPlayable(_ streams: [Stream], maxResolution: ResolutionSetting, formatOrder: [QualityProfile.Format]) -> Stream? {
+        // filter out non HLS streams
+        let nonHLSStreams = streams.filter { $0.kind != .hls }
+
+        // find max resolution from non HLS streams
+        let bestResolution = nonHLSStreams
+            .filter { $0.resolution <= maxResolution.value }
+            .max { $0.resolution < $1.resolution }?.resolution
+
         return streams.map { stream in
             if stream.kind == .hls {
-                stream.resolution = maxResolution.value
+                stream.resolution = bestResolution ?? maxResolution.value
                 stream.format = .hls
             } else if stream.kind == .stream {
                 stream.format = .stream

--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -673,7 +673,7 @@ final class PlayerModel: ObservableObject {
         }
 
         guard let video = currentVideo else { return }
-        guard let stream = avPlayerBackend.bestPlayable(availableStreams, maxResolution: .hd720p30) else { return }
+        guard let stream = backend.bestPlayable(availableStreams, maxResolution: .hd720p30, formatOrder: qualityProfile!.formats) else { return }
 
         exitFullScreen()
 

--- a/Model/Player/PlayerQueue.swift
+++ b/Model/Player/PlayerQueue.swift
@@ -127,12 +127,12 @@ extension PlayerModel {
 
         if let streamPreferredForProfile = backend.bestPlayable(
             availableStreams.filter { backend.canPlay($0) && profile.isPreferred($0) },
-            maxResolution: profile.resolution
+            maxResolution: profile.resolution, formatOrder: profile.formats
         ) {
             return streamPreferredForProfile
         }
 
-        return backend.bestPlayable(availableStreams.filter { backend.canPlay($0) }, maxResolution: profile.resolution)
+        return backend.bestPlayable(availableStreams.filter { backend.canPlay($0) }, maxResolution: profile.resolution, formatOrder: profile.formats)
     }
 
     func advanceToNextItem() {

--- a/Model/QualityProfile.swift
+++ b/Model/QualityProfile.swift
@@ -3,13 +3,13 @@ import Foundation
 
 struct QualityProfile: Hashable, Identifiable, Defaults.Serializable {
     static var bridge = QualityProfileBridge()
-    static var defaultProfile = Self(id: "default", backend: .mpv, resolution: .hd720p60, formats: [.stream])
+    static var defaultProfile = Self(id: "default", backend: .mpv, resolution: .hd720p60, formats: [.stream], order: Array(Format.allCases.indices))
 
     enum Format: String, CaseIterable, Identifiable, Defaults.Serializable {
         case hls
         case stream
-        case mp4
         case avc1
+        case mp4
         case av1
         case webm
 
@@ -23,7 +23,6 @@ struct QualityProfile: Hashable, Identifiable, Defaults.Serializable {
                 return "Stream"
             case .webm:
                 return "WebM"
-
             default:
                 return rawValue.uppercased()
             }
@@ -35,14 +34,14 @@ struct QualityProfile: Hashable, Identifiable, Defaults.Serializable {
                 return nil
             case .stream:
                 return nil
-            case .mp4:
-                return .mp4
-            case .webm:
-                return .webm
             case .avc1:
                 return .avc1
+            case .mp4:
+                return .mp4
             case .av1:
                 return .av1
+            case .webm:
+                return .webm
             }
         }
     }
@@ -53,7 +52,7 @@ struct QualityProfile: Hashable, Identifiable, Defaults.Serializable {
     var backend: PlayerBackendType
     var resolution: ResolutionSetting
     var formats: [Format]
-
+    var order: [Int]
     var description: String {
         if let name, !name.isEmpty { return name }
         return "\(backend.label) - \(resolution.description) - \(formatsDescription)"
@@ -101,7 +100,8 @@ struct QualityProfileBridge: Defaults.Bridge {
             "name": value.name ?? "",
             "backend": value.backend.rawValue,
             "resolution": value.resolution.rawValue,
-            "formats": value.formats.map { $0.rawValue }.joined(separator: Self.formatsSeparator)
+            "formats": value.formats.map { $0.rawValue }.joined(separator: Self.formatsSeparator),
+            "order": value.order.map { String($0) }.joined(separator: Self.formatsSeparator) // New line
         ]
     }
 
@@ -116,7 +116,8 @@ struct QualityProfileBridge: Defaults.Bridge {
 
         let name = object["name"]
         let formats = (object["formats"] ?? "").components(separatedBy: Self.formatsSeparator).compactMap { QualityProfile.Format(rawValue: $0) }
+        let order = (object["order"] ?? "").components(separatedBy: Self.formatsSeparator).compactMap { Int($0) }
 
-        return .init(id: id, name: name, backend: backend, resolution: resolution, formats: formats)
+        return .init(id: id, name: name, backend: backend, resolution: resolution, formats: formats, order: order)
     }
 }

--- a/Model/Stream.swift
+++ b/Model/Stream.swift
@@ -54,6 +54,32 @@ class Stream: Equatable, Hashable, Identifiable {
             return Int(refreshRatePart.components(separatedBy: CharacterSet.decimalDigits.inverted).joined()) ?? -1
         }
 
+        // These values are an approximation.
+        // https://support.google.com/youtube/answer/1722171?hl=en#zippy=%2Cbitrate
+
+        var bitrate: Int {
+            switch self {
+            case .hd2160p60, .hd2160p50, .hd2160p48, .hd2160p30:
+                return 56000000 // 56 Mbit/s
+            case .hd1440p60, .hd1440p50, .hd1440p48, .hd1440p30:
+                return 24000000 // 24 Mbit/s
+            case .hd1080p60, .hd1080p50, .hd1080p48, .hd1080p30:
+                return 12000000 // 12 Mbit/s
+            case .hd720p60, .hd720p50, .hd720p48, .hd720p30:
+                return 9500000 // 9.5 Mbit/s
+            case .sd480p30:
+                return 4000000 // 4 Mbit/s
+            case .sd360p30:
+                return 1500000 // 1.5 Mbit/s
+            case .sd240p30:
+                return 1000000 // 1 Mbit/s
+            case .sd144p30:
+                return 600000 // 0.6 Mbit/s
+            case .unknown:
+                return 0
+            }
+        }
+
         static func from(resolution: String, fps: Int? = nil) -> Self {
             allCases.first { $0.rawValue.contains(resolution) && $0.refreshRate == (fps ?? 30) } ?? .unknown
         }
@@ -143,6 +169,7 @@ class Stream: Equatable, Hashable, Identifiable {
 
     var encoding: String?
     var videoFormat: String?
+    var bitrate: Int?
 
     init(
         instance: Instance? = nil,
@@ -153,7 +180,8 @@ class Stream: Equatable, Hashable, Identifiable {
         resolution: Resolution? = nil,
         kind: Kind = .hls,
         encoding: String? = nil,
-        videoFormat: String? = nil
+        videoFormat: String? = nil,
+        bitrate: Int? = nil
     ) {
         self.instance = instance
         self.audioAsset = audioAsset
@@ -164,6 +192,7 @@ class Stream: Equatable, Hashable, Identifiable {
         self.kind = kind
         self.encoding = encoding
         format = .from(videoFormat ?? "")
+        self.bitrate = bitrate
     }
 
     var isLocal: Bool {

--- a/Model/Stream.swift
+++ b/Model/Stream.swift
@@ -176,6 +176,11 @@ class Stream: Equatable, Hashable, Identifiable {
 
     var quality: String {
         guard localURL.isNil else { return "Opened File" }
+
+        if kind == .hls {
+            return "adaptive (HLS)"
+        }
+
         return resolution.name
     }
 
@@ -183,7 +188,7 @@ class Stream: Equatable, Hashable, Identifiable {
         guard localURL.isNil else { return "File" }
 
         if kind == .hls {
-            return format.description
+            return "adaptive (HLS)"
         }
 
         if kind == .stream {
@@ -195,7 +200,7 @@ class Stream: Equatable, Hashable, Identifiable {
     var description: String {
         guard localURL.isNil else { return resolutionAndFormat }
         let instanceString = instance.isNil ? "" : " - (\(instance!.description))"
-        return format != .hls ? "\(resolutionAndFormat)\(instanceString)" : "\(format.description)\(instanceString)"
+        return format != .hls ? "\(resolutionAndFormat)\(instanceString)" : "adaptive (HLS)\(instanceString)"
     }
 
     var resolutionAndFormat: String {

--- a/Model/Stream.swift
+++ b/Model/Stream.swift
@@ -64,7 +64,7 @@ class Stream: Equatable, Hashable, Identifiable {
     }
 
     enum Kind: String, Comparable {
-        case stream, adaptive, hls
+        case hls, adaptive, stream
 
         private var sortOrder: Int {
             switch self {
@@ -82,37 +82,23 @@ class Stream: Equatable, Hashable, Identifiable {
         }
     }
 
-    enum Format: String, Comparable {
-        case webm
+    enum Format: String {
         case avc1
-        case av1
         case mp4
+        case av1
+        case webm
+        case hls
+        case stream
         case unknown
-
-        private var sortOrder: Int {
-            switch self {
-            case .mp4:
-                return 0
-            case .avc1:
-                return 1
-            case .av1:
-                return 2
-            case .webm:
-                return 3
-            case .unknown:
-                return 4
-            }
-        }
-
-        static func < (lhs: Self, rhs: Self) -> Bool {
-            lhs.sortOrder < rhs.sortOrder
-        }
 
         var description: String {
             switch self {
             case .webm:
                 return "WebM"
-
+            case .hls:
+                return "adaptive (HLS)"
+            case .stream:
+                return "Stream"
             default:
                 return rawValue.uppercased()
             }
@@ -121,17 +107,23 @@ class Stream: Equatable, Hashable, Identifiable {
         static func from(_ string: String) -> Self {
             let lowercased = string.lowercased()
 
-            if lowercased.contains("webm") {
-                return .webm
-            }
             if lowercased.contains("avc1") {
                 return .avc1
+            }
+            if lowercased.contains("mpeg_4") || lowercased.contains("mp4") {
+                return .mp4
             }
             if lowercased.contains("av01") {
                 return .av1
             }
-            if lowercased.contains("mpeg_4") || lowercased.contains("mp4") {
-                return .mp4
+            if lowercased.contains("webm") {
+                return .webm
+            }
+            if lowercased.contains("stream") {
+                return .stream
+            }
+            if lowercased.contains("hls") {
+                return .hls
             }
             return .unknown
         }
@@ -184,22 +176,26 @@ class Stream: Equatable, Hashable, Identifiable {
 
     var quality: String {
         guard localURL.isNil else { return "Opened File" }
-        return kind == .hls ? "adaptive (HLS)" : "\(resolution.name)\(kind == .stream ? " (\(kind.rawValue))" : "")"
+        return resolution.name
     }
 
     var shortQuality: String {
         guard localURL.isNil else { return "File" }
 
         if kind == .hls {
-            return "HLS"
+            return format.description
         }
-        return resolution?.name ?? "?"
+
+        if kind == .stream {
+            return resolution.name
+        }
+        return resolutionAndFormat
     }
 
     var description: String {
         guard localURL.isNil else { return resolutionAndFormat }
         let instanceString = instance.isNil ? "" : " - (\(instance!.description))"
-        return "\(resolutionAndFormat)\(instanceString)"
+        return format != .hls ? "\(resolutionAndFormat)\(instanceString)" : "\(format.description)\(instanceString)"
     }
 
     var resolutionAndFormat: String {

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -5,6 +5,23 @@ import SwiftUI
 enum Constants {
     static let yatteeProtocol = "yattee://"
     static let overlayAnimation = Animation.linear(duration: 0.2)
+
+    static var isAppleTV: Bool {
+        #if os(iOS)
+            UIDevice.current.userInterfaceIdiom == .tv
+        #else
+            false
+        #endif
+    }
+
+    static var isMac: Bool {
+        #if os(iOS)
+            UIDevice.current.userInterfaceIdiom == .mac
+        #else
+            false
+        #endif
+    }
+
     static var isIPhone: Bool {
         #if os(iOS)
             UIDevice.current.userInterfaceIdiom == .phone

--- a/Shared/Defaults.swift
+++ b/Shared/Defaults.swift
@@ -165,11 +165,11 @@ extension Defaults.Keys {
 
     // MARK: GROUP - Quality
 
-    static let hd2160pMPVProfile = QualityProfile(id: "hd2160pMPVProfile", backend: .mpv, resolution: .hd2160p60, formats: QualityProfile.Format.allCases)
-    static let hd1080pMPVProfile = QualityProfile(id: "hd1080pMPVProfile", backend: .mpv, resolution: .hd1080p60, formats: QualityProfile.Format.allCases)
-    static let hd720pMPVProfile = QualityProfile(id: "hd720pMPVProfile", backend: .mpv, resolution: .hd720p60, formats: QualityProfile.Format.allCases)
-    static let hd720pAVPlayerProfile = QualityProfile(id: "hd720pAVPlayerProfile", backend: .appleAVPlayer, resolution: .hd720p60, formats: [.hls, .stream])
-    static let sd360pAVPlayerProfile = QualityProfile(id: "sd360pAVPlayerProfile", backend: .appleAVPlayer, resolution: .sd360p30, formats: [.hls, .stream])
+    static let hd2160pMPVProfile = QualityProfile(id: "hd2160pMPVProfile", backend: .mpv, resolution: .hd2160p60, formats: QualityProfile.Format.allCases, order: Array(QualityProfile.Format.allCases.indices))
+    static let hd1080pMPVProfile = QualityProfile(id: "hd1080pMPVProfile", backend: .mpv, resolution: .hd1080p60, formats: QualityProfile.Format.allCases, order: Array(QualityProfile.Format.allCases.indices))
+    static let hd720pMPVProfile = QualityProfile(id: "hd720pMPVProfile", backend: .mpv, resolution: .hd720p60, formats: QualityProfile.Format.allCases, order: Array(QualityProfile.Format.allCases.indices))
+    static let hd720pAVPlayerProfile = QualityProfile(id: "hd720pAVPlayerProfile", backend: .appleAVPlayer, resolution: .hd720p60, formats: [.hls, .stream], order: Array(QualityProfile.Format.allCases.indices))
+    static let sd360pAVPlayerProfile = QualityProfile(id: "sd360pAVPlayerProfile", backend: .appleAVPlayer, resolution: .sd360p30, formats: [.hls, .stream], order: Array(QualityProfile.Format.allCases.indices))
 
     #if os(iOS)
         static let qualityProfilesDefault = UIDevice.current.userInterfaceIdiom == .pad ? [

--- a/Shared/Settings/MultiselectRow.swift
+++ b/Shared/Settings/MultiselectRow.swift
@@ -9,9 +9,23 @@ struct MultiselectRow: View {
     @State private var toggleChecked = false
 
     var body: some View {
-        #if os(macOS)
+        #if os(tvOS)
+            Button(action: { action(!selected) }) {
+                HStack {
+                    Text(self.title)
+                    Spacer()
+                    if selected {
+                        Image(systemName: "checkmark")
+                    }
+                }
+                .contentShape(Rectangle())
+            }
+            .disabled(disabled)
+        #else
             Toggle(title, isOn: $toggleChecked)
+            #if os(macOS)
                 .toggleStyle(.checkbox)
+            #endif
                 .onAppear {
                     guard !disabled else { return }
                     toggleChecked = selected
@@ -19,24 +33,6 @@ struct MultiselectRow: View {
                 .onChange(of: toggleChecked) { new in
                     action(new)
                 }
-        #else
-            Button(action: { action(!selected) }) {
-                HStack {
-                    Text(self.title)
-                    Spacer()
-                    if selected {
-                        Image(systemName: "checkmark")
-                        #if os(iOS)
-                            .foregroundColor(.accentColor)
-                        #endif
-                    }
-                }
-                .contentShape(Rectangle())
-            }
-            .disabled(disabled)
-            #if !os(tvOS)
-                .buttonStyle(.plain)
-            #endif
         #endif
     }
 }

--- a/Shared/Settings/QualityProfileForm.swift
+++ b/Shared/Settings/QualityProfileForm.swift
@@ -1,6 +1,11 @@
 import Defaults
 import SwiftUI
 
+struct FormatState: Equatable {
+    let format: QualityProfile.Format
+    var isActive: Bool
+}
+
 struct QualityProfileForm: View {
     @Binding var qualityProfileID: QualityProfile.ID?
 
@@ -15,6 +20,7 @@ struct QualityProfileForm: View {
     @State private var backend = PlayerBackendType.mpv
     @State private var resolution = ResolutionSetting.hd1080p60
     @State private var formats = [QualityProfile.Format]()
+    @State private var orderedFormats: [FormatState] = []
 
     @Default(.qualityProfiles) private var qualityProfiles
 
@@ -26,6 +32,7 @@ struct QualityProfileForm: View {
         return nil
     }
 
+    // swiftlint:disable trailing_closure
     var body: some View {
         VStack {
             Group {
@@ -40,8 +47,11 @@ struct QualityProfileForm: View {
         #endif
 
         .onAppear(perform: initializeForm)
-        .onChange(of: backend, perform: backendChanged)
-        .onChange(of: formats) { _ in validate() }
+        .onChange(of: backend, perform: { _ in backendChanged(self.backend); updateActiveFormats(); validate() })
+
+        .onChange(of: name, perform: { _ in validate() })
+        .onChange(of: resolution, perform: { _ in validate() })
+        .onChange(of: orderedFormats, perform: { _ in validate() })
         #if os(iOS)
             .padding(.vertical)
         #elseif os(tvOS)
@@ -52,6 +62,8 @@ struct QualityProfileForm: View {
             .padding(.vertical, 10)
         #endif
     }
+
+    // swiftlint:enable trailing_closure
 
     var header: some View {
         HStack {
@@ -124,9 +136,16 @@ struct QualityProfileForm: View {
     }
 
     var formatsFooter: some View {
-        Text("Formats will be selected in order as listed.\nHLS is an adaptive format (resolution setting does not apply).")
-            .foregroundColor(.secondary)
-            .fixedSize(horizontal: false, vertical: true)
+        VStack(alignment: .leading) {
+            Text("Formats can be reordered and will be selected in this order.")
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Text("**Note:** HLS is an adaptive format, resolution setting doesn't apply.")
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.top, 0.1)
+        }
+        .padding(.top, 2)
     }
 
     @ViewBuilder var qualityPicker: some View {
@@ -199,17 +218,25 @@ struct QualityProfileForm: View {
         #endif
     }
 
+    var filteredFormatList: some View {
+        ForEach(Array(orderedFormats.enumerated()), id: \.element.format) { idx, element in
+            let format = element.format
+            MultiselectRow(
+                title: format.description,
+                selected: element.isActive
+            ) { value in
+                orderedFormats[idx].isActive = value
+            }
+        }
+        .onMove { source, destination in
+            orderedFormats.move(fromOffsets: source, toOffset: destination)
+            validate()
+        }
+    }
+
     @ViewBuilder var formatsPicker: some View {
         #if os(macOS)
-            let list = ForEach(QualityProfile.Format.allCases, id: \.self) { format in
-                MultiselectRow(
-                    title: format.description,
-                    selected: isFormatSelected(format),
-                    disabled: isFormatDisabled(format)
-                ) { value in
-                    toggleFormat(format, value: value)
-                }
-            }
+            let list = filteredFormatList
 
             Group {
                 if #available(macOS 12.0, *) {
@@ -222,28 +249,19 @@ struct QualityProfileForm: View {
             }
             Spacer()
         #else
-            ForEach(QualityProfile.Format.allCases, id: \.self) { format in
-                MultiselectRow(
-                    title: format.description,
-                    selected: isFormatSelected(format),
-                    disabled: isFormatDisabled(format)
-                ) { value in
-                    toggleFormat(format, value: value)
-                }
-            }
+            filteredFormatList
         #endif
     }
 
     func isFormatSelected(_ format: QualityProfile.Format) -> Bool {
-        (initialized || qualityProfile.isNil ? formats : qualityProfile.formats).contains(format)
+        return orderedFormats.first { $0.format == format }?.isActive ?? false
     }
 
     func toggleFormat(_ format: QualityProfile.Format, value: Bool) {
-        if let index = formats.firstIndex(where: { $0 == format }), !value {
-            formats.remove(at: index)
-        } else if value {
-            formats.append(format)
+        if let index = orderedFormats.firstIndex(where: { $0.format == format }) {
+            orderedFormats[index].isActive = value
         }
+        validate() // Check validity after a toggle operation
     }
 
     var footer: some View {
@@ -274,6 +292,12 @@ struct QualityProfileForm: View {
         return !avPlayerFormats.contains(format)
     }
 
+    func updateActiveFormats() {
+        for (index, format) in orderedFormats.enumerated() where isFormatDisabled(format.format) {
+            orderedFormats[index].isActive = false
+        }
+    }
+
     func isResolutionDisabled(_ resolution: ResolutionSetting) -> Bool {
         guard backend == .appleAVPlayer else { return false }
 
@@ -281,27 +305,39 @@ struct QualityProfileForm: View {
     }
 
     func initializeForm() {
-        guard editing else {
-            validate()
-            return
+        if editing {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                self.name = qualityProfile.name ?? ""
+                self.backend = qualityProfile.backend
+                self.resolution = qualityProfile.resolution
+                self.orderedFormats = qualityProfile.order.map { order in
+                    let format = QualityProfile.Format.allCases[order]
+                    let isActive = qualityProfile.formats.contains(format)
+                    return FormatState(format: format, isActive: isActive)
+                }
+                self.initialized = true
+            }
+        } else {
+            name = ""
+            backend = .mpv
+            resolution = .hd720p60
+            orderedFormats = QualityProfile.Format.allCases.map {
+                FormatState(format: $0, isActive: true)
+            }
+            initialized = true
         }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            self.name = qualityProfile.name ?? ""
-            self.backend = qualityProfile.backend
-            self.resolution = qualityProfile.resolution
-            self.formats = .init(qualityProfile.formats)
-            self.initialized = true
-        }
-
         validate()
     }
 
     func backendChanged(_: PlayerBackendType) {
-        formats.filter { isFormatDisabled($0) }.forEach { format in
-            if let index = formats.firstIndex(where: { $0 == format }) {
-                formats.remove(at: index)
-            }
+        let defaultFormats = QualityProfile.Format.allCases.map {
+            FormatState(format: $0, isActive: true)
+        }
+
+        if backend == .appleAVPlayer {
+            orderedFormats = orderedFormats.filter { !isFormatDisabled($0.format) }
+        } else {
+            orderedFormats = defaultFormats
         }
 
         if isResolutionDisabled(resolution),
@@ -312,20 +348,33 @@ struct QualityProfileForm: View {
     }
 
     func validate() {
-        valid = !formats.isEmpty
+        if !initialized {
+            valid = false
+        } else if editing {
+            let savedOrderFormats = qualityProfile.order.map { order in
+                let format = QualityProfile.Format.allCases[order]
+                let isActive = qualityProfile.formats.contains(format)
+                return FormatState(format: format, isActive: isActive)
+            }
+            valid = name != qualityProfile.name
+                || backend != qualityProfile.backend
+                || resolution != qualityProfile.resolution
+                || orderedFormats != savedOrderFormats
+        } else { valid = true }
     }
 
     func submitForm() {
         guard valid else { return }
 
-        formats = formats.unique()
+        let activeFormats = orderedFormats.filter { $0.isActive }.map { $0.format }
 
         let formProfile = QualityProfile(
             id: qualityProfile?.id ?? UUID().uuidString,
             name: name,
             backend: backend,
             resolution: resolution,
-            formats: Array(formats)
+            formats: activeFormats,
+            order: orderedFormats.map { QualityProfile.Format.allCases.firstIndex(of: $0.format)! }
         )
 
         if editing {

--- a/Shared/Settings/QualityProfileForm.swift
+++ b/Shared/Settings/QualityProfileForm.swift
@@ -140,7 +140,11 @@ struct QualityProfileForm: View {
             Text("Formats can be reordered and will be selected in this order.")
                 .foregroundColor(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
-            Text("**Note:** HLS is an adaptive format, resolution setting doesn't apply.")
+            Text("**Note:** HLS is an adaptive format where specific resolution settings don't apply.")
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.top)
+            Text("Yattee attempts to match the quality that is closest to the set resolution, but exact results cannot be guaranteed.")
                 .foregroundColor(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.top, 0.1)
@@ -301,7 +305,7 @@ struct QualityProfileForm: View {
     func isResolutionDisabled(_ resolution: ResolutionSetting) -> Bool {
         guard backend == .appleAVPlayer else { return false }
 
-        return resolution.value > .hd720p30
+        return resolution.value > .hd1080p60
     }
 
     func initializeForm() {

--- a/Shared/YatteeApp.swift
+++ b/Shared/YatteeApp.swift
@@ -204,6 +204,7 @@ struct YatteeApp: App {
         URLBookmarkModel.shared.refreshAll()
 
         migrateHomeHistoryItems()
+        migrateQualityProfiles()
     }
 
     func migrateHomeHistoryItems() {
@@ -219,6 +220,16 @@ struct YatteeApp: App {
         }
 
         Defaults[.homeHistoryItems] = -1
+    }
+
+    @Default(.qualityProfiles) private var qualityProfilesData
+
+    func migrateQualityProfiles() {
+        for profile in qualityProfilesData where profile.order.isEmpty {
+            var updatedProfile = profile
+            updatedProfile.order = Array(QualityProfile.Format.allCases.indices)
+            QualityProfilesModel.shared.update(profile, updatedProfile)
+        }
     }
 
     var navigationStyle: NavigationStyle {


### PR DESCRIPTION
HLS: try matching the set resolution. This works okay with AVPlayer. With MPV it is hit-and-miss, most of the time, MPV targets the highest available bitrate, instead of the set bitrate.

AVPlayer now supports higher resolution up to 1080p60.

This PR is a follow-up to #650