### PR TITLE
HomeView: Changes to Favourites and History Widget

### DIFF
--- a/Shared/Home/FavoriteItemView.swift
+++ b/Shared/Home/FavoriteItemView.swift
@@ -5,6 +5,7 @@ import UniformTypeIdentifiers
 
 struct FavoriteItemView: View {
     var item: FavoriteItem
+    @Binding var favoritesChanged: Bool
 
     @Environment(\.navigationStyle) private var navigationStyle
     @StateObject private var store = FavoriteResourceObserver()
@@ -25,8 +26,9 @@ struct FavoriteItemView: View {
     @Default(.widgetsSettings) private var widgetsSettings
     @Default(.visibleSections) private var visibleSections
 
-    init(item: FavoriteItem) {
+    init(item: FavoriteItem, favoritesChanged: Binding<Bool>) {
         self.item = item
+        _favoritesChanged = favoritesChanged
     }
 
     var body: some View {
@@ -92,6 +94,7 @@ struct FavoriteItemView: View {
                 .onChange(of: player.currentVideo) { _ in reloadVisibleWatches() }
                 .onChange(of: hideShorts) { _ in reloadVisibleWatches() }
                 .onChange(of: hideWatched) { _ in reloadVisibleWatches() }
+                .onChange(of: favoritesChanged) { _ in reloadVisibleWatches() }
             }
         }
         .id(watchModel.historyToken)
@@ -486,14 +489,22 @@ struct FavoriteItemView: View {
 }
 
 struct FavoriteItemView_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationView {
-            VStack {
-                FavoriteItemView(item: .init(section: .channel("peerTube", "a", "Search: resistance body upper band workout")))
-                    .environment(\.navigationStyle, .tab)
-                FavoriteItemView(item: .init(section: .channel("peerTube", "a", "Marques")))
-                    .environment(\.navigationStyle, .sidebar)
+    struct PreviewWrapper: View {
+        @State private var favoritesChanged = false
+
+        var body: some View {
+            NavigationView {
+                VStack {
+                    FavoriteItemView(item: .init(section: .channel("peerTube", "a", "Search: resistance body upper band workout")), favoritesChanged: $favoritesChanged)
+                        .environment(\.navigationStyle, .tab)
+                    FavoriteItemView(item: .init(section: .channel("peerTube", "a", "Marques")), favoritesChanged: $favoritesChanged)
+                        .environment(\.navigationStyle, .sidebar)
+                }
             }
         }
+    }
+
+    static var previews: some View {
+        PreviewWrapper()
     }
 }

--- a/Shared/Home/HistoryView.swift
+++ b/Shared/Home/HistoryView.swift
@@ -1,18 +1,13 @@
 import SwiftUI
 
 struct HistoryView: View {
-    var limit = 10
+    var limit: Int
 
     @FetchRequest(sortDescriptors: [.init(key: "watchedAt", ascending: false)])
     var watches: FetchedResults<Watch>
 
     @ObservedObject private var player = PlayerModel.shared
-
     @State private var visibleWatches = [Watch]()
-
-    init(limit: Int = 10) {
-        self.limit = limit
-    }
 
     var body: some View {
         LazyVStack {
@@ -38,10 +33,14 @@ struct HistoryView: View {
     func reloadVisibleWatches() {
         visibleWatches = Array(watches.filter { $0.videoID != player.currentVideo?.videoID }.prefix(limit))
     }
+
+    init(limit: Int = 10) {
+        self.limit = limit
+    }
 }
 
 struct HistoryView_Previews: PreviewProvider {
     static var previews: some View {
-        HistoryView()
+        HistoryView(limit: 10)
     }
 }

--- a/Shared/Home/HomeView.swift
+++ b/Shared/Home/HomeView.swift
@@ -97,11 +97,11 @@ struct HomeView: View {
                 VStack(alignment: .leading) {
                     #if os(tvOS)
                         ForEach(Defaults[.favorites]) { item in
-                            FavoriteItemView(item: item)
+                            FavoriteItemView(item: item, favoritesChanged: $favoritesChanged)
                         }
                     #else
                         ForEach(favorites) { item in
-                            FavoriteItemView(item: item)
+                            FavoriteItemView(item: item, favoritesChanged: $favoritesChanged)
                             #if os(macOS)
                                 .workaroundForVerticalScrollingBug()
                             #endif

--- a/Shared/Videos/ListView.swift
+++ b/Shared/Videos/ListView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct ListView: View {
     var items: [ContentItem]
-    var limit: Int? = 10
+    var limit: Int?
 
     var body: some View {
         LazyVStack(alignment: .leading) {
@@ -16,16 +16,12 @@ struct ListView: View {
     }
 
     var limitedItems: [ContentItem] {
-        if let limit, limit >= 0 {
-            return Array(items.prefix(limit))
-        }
-
-        return items
+        Array(items.prefix(limit ?? items.count))
     }
 }
 
 struct ListView_Previews: PreviewProvider {
     static var previews: some View {
-        ListView(items: [.init(video: .fixture)])
+        ListView(items: [.init(video: .fixture)], limit: 10)
     }
 }


### PR DESCRIPTION
The History Widget in the Home View was hard-coded to 10 items. Now it uses the limit set in the settings.

The items weren't immediate updated when the limit was changed.

List Views had a hard-coded limit of 10 items. Now they use the limit supplied in the parameter.