### PR TITLE
Advanced Settings: cache-pause-initial

### DIFF
--- a/Model/Player/Backends/MPVClient.swift
+++ b/Model/Player/Backends/MPVClient.swift
@@ -60,7 +60,7 @@ final class MPVClient: ObservableObject {
             checkError(mpv_set_option_string(mpv, "input-media-keys", "yes"))
         #endif
 
-        checkError(mpv_set_option_string(mpv, "cache-pause-initial", "yes"))
+        checkError(mpv_set_option_string(mpv, "cache-pause-initial", Defaults[.mpvCachePauseInital] ? "yes" : "no"))
         checkError(mpv_set_option_string(mpv, "cache-secs", Defaults[.mpvCacheSecs]))
         checkError(mpv_set_option_string(mpv, "cache-pause-wait", Defaults[.mpvCachePauseWait]))
         checkError(mpv_set_option_string(mpv, "keep-open", "yes"))

--- a/Shared/Defaults.swift
+++ b/Shared/Defaults.swift
@@ -266,6 +266,7 @@ extension Defaults.Keys {
     static let mpvEnableLogging = Key<Bool>("mpvEnableLogging", default: false)
     static let mpvCacheSecs = Key<String>("mpvCacheSecs", default: "120")
     static let mpvCachePauseWait = Key<String>("mpvCachePauseWait", default: "3")
+    static let mpvCachePauseInital = Key<Bool>("cache-pause-initial", default: true)
     static let mpvDeinterlace = Key<Bool>("mpvDeinterlace", default: false)
 
     static let showCacheStatus = Key<Bool>("showCacheStatus", default: false)

--- a/Shared/Settings/AdvancedSettings.swift
+++ b/Shared/Settings/AdvancedSettings.swift
@@ -5,6 +5,7 @@ struct AdvancedSettings: View {
     @Default(.showMPVPlaybackStats) private var showMPVPlaybackStats
     @Default(.mpvCacheSecs) private var mpvCacheSecs
     @Default(.mpvCachePauseWait) private var mpvCachePauseWait
+    @Default(.mpvCachePauseInital) private var mpvCachePauseInital
     @Default(.mpvDeinterlace) private var mpvDeinterlace
     @Default(.mpvEnableLogging) private var mpvEnableLogging
     @Default(.showCacheStatus) private var showCacheStatus
@@ -68,9 +69,32 @@ struct AdvancedSettings: View {
                 mpvEnableLoggingToggle
             #endif
 
+            Toggle(isOn: $mpvCachePauseInital) {
+                HStack {
+                    Text("cache-pause-initial")
+                    #if !os(tvOS)
+                        Link(destination: URL(string: "https://mpv.io/manual/stable/#options-cache-pause-initial")!) {
+                            Image(systemName: "link")
+                                .font(.footnote)
+                        }
+                        #if os(macOS)
+                        .onHover(perform: onHover(_:))
+                        #endif
+                    #endif
+                }
+            }
+
             HStack {
                 Text("cache-secs")
-                    .frame(minWidth: 140, alignment: .leading)
+                #if !os(tvOS)
+                    Link(destination: URL(string: "https://mpv.io/manual/stable/#options-cache-secs")!) {
+                        Image(systemName: "link")
+                            .font(.footnote)
+                        #if os(macOS)
+                            .onHover(perform: onHover(_:))
+                        #endif
+                    }
+                #endif
                 TextField("cache-secs", text: $mpvCacheSecs)
                 #if !os(macOS)
                     .keyboardType(.numberPad)
@@ -79,8 +103,19 @@ struct AdvancedSettings: View {
             .multilineTextAlignment(.trailing)
 
             HStack {
-                Text("cache-pause-wait")
-                    .frame(minWidth: 140, alignment: .leading)
+                Group {
+                    Text("cache-pause-wait")
+                    #if !os(tvOS)
+                        Link(destination: URL(string: "https://mpv.io/manual/stable/#options-cache-pause-wait")!) {
+                            Image(systemName: "link")
+                        }
+                        .font(.footnote)
+                    #endif
+                    #if os(macOS)
+                    .onHover(perform: onHover(_:))
+                    #endif
+                }.frame(minWidth: 140, alignment: .leading)
+
                 TextField("cache-pause-wait", text: $mpvCachePauseWait)
                 #if !os(macOS)
                     .keyboardType(.numberPad)
@@ -88,7 +123,20 @@ struct AdvancedSettings: View {
             }
             .multilineTextAlignment(.trailing)
 
-            Toggle("deinterlace", isOn: $mpvDeinterlace)
+            Toggle(isOn: $mpvDeinterlace) {
+                HStack {
+                    Text("deinterlace")
+                    #if !os(tvOS)
+                        Link(destination: URL(string: "https://mpv.io/manual/stable/#options-deinterlace")!) {
+                            Image(systemName: "link")
+                                .font(.footnote)
+                        }
+                        #if os(macOS)
+                        .onHover(perform: onHover(_:))
+                        #endif
+                    #endif
+                }
+            }
 
             if mpvEnableLogging {
                 logButton
@@ -103,20 +151,19 @@ struct AdvancedSettings: View {
     }
 
     @ViewBuilder var mpvFooter: some View {
-        let url = "https://mpv.io/manual/master"
+        let url = "https://mpv.io/manual/stable/"
 
         VStack(alignment: .leading) {
             Text("Restart the app to apply the settings above.")
+                .padding(.bottom, 1)
             VStack(alignment: .leading, spacing: 2) {
                 #if os(tvOS)
-                    Text("More info can be found in MPV Documentation:")
+                    Text("More info can be found in MPV reference manual:")
                     Text(url)
                 #else
-                    Text("More info can be found in:")
-                    Link("MPV Documentation", destination: URL(string: url)!)
-                    #if os(macOS)
-                        .onHover(perform: onHover(_:))
-                    #endif
+                    Text("Further information can be found in the ")
+                        + Text("MPV reference manual").underline().bold()
+                        + Text(" by clicking on the link icon next to the option.")
                 #endif
             }
         }


### PR DESCRIPTION
`cache-pause-initial` status can now be selected by the user.

Also, on macOS and iOS, a link next to the option leads the user to the info on the mpv website.