### PR TITLE
Invidious: add images to chapters

### DIFF
--- a/Model/Applications/InvidiousAPI.swift
+++ b/Model/Applications/InvidiousAPI.swift
@@ -502,7 +502,7 @@ final class InvidiousAPI: Service, ObservableObject, VideosAPI {
             keywords: json["keywords"].arrayValue.compactMap { $0.string },
             streams: extractStreams(from: json),
             related: extractRelated(from: json),
-            chapters: extractChapters(from: description),
+            chapters: createChapters(from: description, thumbnails: json),
             captions: extractCaptions(from: json)
         )
     }
@@ -573,6 +573,22 @@ final class InvidiousAPI: Service, ObservableObject, VideosAPI {
 
             return Thumbnail(url: thumbnailUrl, quality: .init(rawValue: quality)!)
         }
+    }
+
+    private func createChapters(from description: String, thumbnails: JSON) -> [Chapter] {
+        var chapters = extractChapters(from: description)
+
+        if !chapters.isEmpty {
+            let thumbnailsData = extractThumbnails(from: thumbnails)
+            let thumbnailURL = thumbnailsData.first { $0.quality == .medium }?.url
+
+            for chapter in chapters.indices {
+                if let url = thumbnailURL {
+                    chapters[chapter].image = url
+                }
+            }
+        }
+        return chapters
     }
 
     private static var contentItemsKeys = ["items", "videos", "latestVideos", "playlists", "relatedChannels"]

--- a/Shared/Player/Video Details/ChapterView.swift
+++ b/Shared/Player/Video Details/ChapterView.swift
@@ -65,7 +65,7 @@ import SwiftUI
         }
 
         static var thumbnailHeight: Double {
-            thumbnailWidth / 1.7777
+            thumbnailWidth / (16 / 9)
         }
     }
 


### PR DESCRIPTION
Invidious, by design, has no images attached to chapters, in contrast to Piped.

Since the majority of videos with chapters don't have chapter-specific images and only use the videos' thumbnail, there is no difference here when compared to Piped's native thumbnail support.