### PR TITLE
Fix thumbnails failing to load on tvOS

### DIFF
--- a/Shared/YatteeApp.swift
+++ b/Shared/YatteeApp.swift
@@ -154,7 +154,12 @@ struct YatteeApp: App {
             #if DEBUG
                 SiestaLog.Category.enabled = .common
             #endif
-            SDImageCodersManager.shared.addCoder(SDImageAWebPCoder.shared)
+            #if os(tvOS)
+                SDImageCodersManager.shared.addCoder(SDImageWebPCoder.shared)
+            #else
+                SDImageCodersManager.shared.addCoder(SDImageAWebPCoder.shared)
+            #endif
+            
             SDWebImageManager.defaultImageCache = PINCache(name: "stream.yattee.app")
 
             if !Defaults[.lastAccountIsPublic] {


### PR DESCRIPTION
- Thumbnails fail to load on tvOS when using `SDImageAWebPCoder`. Use `SDImageWebPCoder` on tvOS.