### PR TITLE
fix duplicated share button

### DIFF
--- a/Model/Player/Backends/MPVClient.swift
+++ b/Model/Player/Backends/MPVClient.swift
@@ -72,6 +72,7 @@ final class MPVClient: ObservableObject {
         checkError(mpv_set_option_string(mpv, "sub-scale", Defaults[.captionsFontScaleSize]))
         checkError(mpv_set_option_string(mpv, "sub-color", Defaults[.captionsFontColor]))
         checkError(mpv_set_option_string(mpv, "user-agent", UserAgentManager.shared.userAgent))
+        checkError(mpv_set_option_string(mpv, "initial-audio-sync", Defaults[.mpvInitialAudioSync] ? "yes" : "no"))
 
         // GPU //
 

--- a/Shared/Defaults.swift
+++ b/Shared/Defaults.swift
@@ -270,6 +270,7 @@ extension Defaults.Keys {
     static let mpvDeinterlace = Key<Bool>("mpvDeinterlace", default: false)
     static let mpvHWdec = Key<String>("hwdec", default: "auto-safe")
     static let mpvDemuxerLavfProbeInfo = Key<String>("mpvDemuxerLavfProbeInfo", default: "no")
+    static let mpvInitialAudioSync = Key<Bool>("mpvInitialAudioSync", default: true)
 
     static let showCacheStatus = Key<Bool>("showCacheStatus", default: false)
     static let feedCacheSize = Key<String>("feedCacheSize", default: "50")

--- a/Shared/Settings/AdvancedSettings.swift
+++ b/Shared/Settings/AdvancedSettings.swift
@@ -10,6 +10,7 @@ struct AdvancedSettings: View {
     @Default(.mpvEnableLogging) private var mpvEnableLogging
     @Default(.mpvHWdec) private var mpvHWdec
     @Default(.mpvDemuxerLavfProbeInfo) private var mpvDemuxerLavfProbeInfo
+    @Default(.mpvInitialAudioSync) private var mpvInitialAudioSync
     @Default(.showCacheStatus) private var showCacheStatus
     @Default(.feedCacheSize) private var feedCacheSize
     @Default(.showPlayNowInBackendContextMenu) private var showPlayNowInBackendContextMenu
@@ -83,6 +84,9 @@ struct AdvancedSettings: View {
                                 UIApplication.shared.open(URL(string: "https://mpv.io/manual/stable/#options-cache-pause-initial")!)
                             }
                         #elseif os(macOS)
+                            .onTapGesture {
+                                NSWorkspace.shared.open(URL(string: "https://mpv.io/manual/stable/#options-cache-pause-initial")!)
+                            }
                             .onHover(perform: onHover(_:))
                         #endif
                     #endif
@@ -100,6 +104,9 @@ struct AdvancedSettings: View {
                             UIApplication.shared.open(URL(string: "https://mpv.io/manual/stable/#options-cache-secs")!)
                         }
                     #elseif os(macOS)
+                        .onTapGesture {
+                            NSWorkspace.shared.open(URL(string: "https://mpv.io/manual/stable/#options-cache-secs")!)
+                        }
                         .onHover(perform: onHover(_:))
                     #endif
 
@@ -123,6 +130,9 @@ struct AdvancedSettings: View {
                                 UIApplication.shared.open(URL(string: "https://mpv.io/manual/stable/#options-cache-pause-wait")!)
                             }
                         #elseif os(macOS)
+                            .onTapGesture {
+                                NSWorkspace.shared.open(URL(string: "https://mpv.io/manual/stable/#options-cache-pause-wait")!)
+                            }
                             .onHover(perform: onHover(_:))
                         #endif
                     #endif
@@ -147,6 +157,30 @@ struct AdvancedSettings: View {
                                 UIApplication.shared.open(URL(string: "https://mpv.io/manual/stable/#options-deinterlace")!)
                             }
                         #elseif os(macOS)
+                            .onTapGesture {
+                                NSWorkspace.shared.open(URL(string: "https://mpv.io/manual/stable/#options-deinterlace")!)
+                            }
+                            .onHover(perform: onHover(_:))
+                        #endif
+                    #endif
+                }
+            }
+
+            Toggle(isOn: $mpvInitialAudioSync) {
+                HStack {
+                    Text("initial-audio-sync")
+                    #if !os(tvOS)
+                        Image(systemName: "link")
+                            .accessibilityAddTraits([.isButton, .isLink])
+                            .font(.footnote)
+                        #if os(iOS)
+                            .onTapGesture {
+                                UIApplication.shared.open(URL(string: "https://mpv.io/manual/stable/#options-initial-audio-sync")!)
+                            }
+                        #elseif os(macOS)
+                            .onTapGesture {
+                                NSWorkspace.shared.open(URL(string: "https://mpv.io/manual/stable/#options-initial-audio-sync")!)
+                            }
                             .onHover(perform: onHover(_:))
                         #endif
                     #endif
@@ -165,6 +199,9 @@ struct AdvancedSettings: View {
                             UIApplication.shared.open(URL(string: "https://mpv.io/manual/stable/#options-hwdec")!)
                         }
                     #elseif os(macOS)
+                        .onTapGesture {
+                            NSWorkspace.shared.open(URL(string: "https://mpv.io/manual/stable/#options-hwdec")!)
+                        }
                         .onHover(perform: onHover(_:))
                     #endif
                 #endif
@@ -179,10 +216,6 @@ struct AdvancedSettings: View {
                 #endif
             }
 
-            if mpvEnableLogging {
-                logButton
-            }
-
             HStack {
                 Text("demuxer-lavf-probe-info")
 
@@ -195,6 +228,9 @@ struct AdvancedSettings: View {
                             UIApplication.shared.open(URL(string: "https://mpv.io/manual/stable/#options-demuxer-lavf-probe-info")!)
                         }
                     #elseif os(macOS)
+                        .onTapGesture {
+                            NSWorkspace.shared.open(URL(string: "https://mpv.io/manual/stable/#options-demuxer-lavf-probe-info")!)
+                        }
                         .onHover(perform: onHover(_:))
                     #endif
                 #endif


### PR DESCRIPTION
fixes #691

add `--initial-audio-sync=<yes|no>` to MPV settings. Might fix #690 but needs to be toggled by the user. We leave the standard settings.

Also added links to the icons on macOS.