### PR TITLE
Improvements to opening channels from Videos

### DIFF
--- a/Shared/Channels/ChannelVideosView.swift
+++ b/Shared/Channels/ChannelVideosView.swift
@@ -380,7 +380,7 @@ struct ChannelVideosView: View {
                                 navigation.sidebarSectionChanged.toggle()
                             }
                         } label: {
-                            Label("Subscribe", systemImage: "circle")
+                            Label("Subscribe", systemImage: "star.circle")
                                 .help("Subscribe")
                             #if os(iOS)
                                 .labelStyle(.automatic)

--- a/Shared/Player/Video Details/VideoDetails.swift
+++ b/Shared/Player/Video Details/VideoDetails.swift
@@ -47,9 +47,12 @@ struct VideoDetails: View {
                 .frame(width: 40, height: 40)
                 .buttonStyle(.plain)
                 .padding(.trailing, 5)
-                .simultaneousGesture(
-                    TapGesture() // Ensures the button tap is recognized
-                )
+                // TODO: when setting tvOS minimum to 16, the platform modifier can be removed
+                #if !os(tvOS)
+                    .simultaneousGesture(
+                        TapGesture() // Ensures the button tap is recognized
+                    )
+                #endif
 
                 VStack(alignment: .leading, spacing: 2) {
                     HStack {
@@ -58,6 +61,14 @@ struct VideoDetails: View {
                                 .font(.subheadline)
                                 .fontWeight(.semibold)
                                 .lineLimit(1)
+                            // TODO: when setting tvOS minimum to 16, the platform modifier can be removed
+                            #if !os(tvOS)
+                                .onTapGesture {
+                                    guard let channel = video?.channel else { return }
+                                    NavigationModel.shared.openChannel(channel, navigationStyle: .sidebar)
+                                }
+                                .accessibilityAddTraits(.isButton)
+                            #endif
                         } else if model.videoBeingOpened != nil {
                             Text("Yattee")
                                 .font(.subheadline)
@@ -211,6 +222,7 @@ struct VideoDetails: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())
             .padding(.horizontal, 16)
+            // TODO: when setting tvOS minimum to 16, the platform modifier can be removed
             #if !os(tvOS)
                 .simultaneousGesture( // Simultaneous gesture to prioritize button tap
                     TapGesture(count: 2).onEnded {

--- a/Shared/Player/Video Details/VideoDetails.swift
+++ b/Shared/Player/Video Details/VideoDetails.swift
@@ -47,6 +47,9 @@ struct VideoDetails: View {
                 .frame(width: 40, height: 40)
                 .buttonStyle(.plain)
                 .padding(.trailing, 5)
+                .simultaneousGesture(
+                    TapGesture() // Ensures the button tap is recognized
+                )
 
                 VStack(alignment: .leading, spacing: 2) {
                     HStack {
@@ -209,9 +212,8 @@ struct VideoDetails: View {
             .contentShape(Rectangle())
             .padding(.horizontal, 16)
             #if !os(tvOS)
-                .tapRecognizer(
-                    tapSensitivity: 0.2,
-                    doubleTapAction: {
+                .simultaneousGesture( // Simultaneous gesture to prioritize button tap
+                    TapGesture(count: 2).onEnded {
                         withAnimation(.default) {
                             fullScreen.toggle()
                         }


### PR DESCRIPTION
- The touch on the channel icon was consumed by the double tab gesture, now it opens the channel.

- Touching the channel name now also opens the channel.

- Added correct icon to the subscribe button in the channel view