### PR TITLE
only updateWatch status while video is playing

### DIFF
--- a/Model/HistoryModel.swift
+++ b/Model/HistoryModel.swift
@@ -47,7 +47,7 @@ extension PlayerModel {
     }
 
     func updateWatch(finished: Bool = false, time: CMTime? = nil) {
-        guard let currentVideo, saveHistory else { return }
+        guard let currentVideo, saveHistory, isPlaying else { return }
 
         let id = currentVideo.videoID
         let time = time ?? backend.currentTime

--- a/Model/Player/Backends/MPVBackend.swift
+++ b/Model/Player/Backends/MPVBackend.swift
@@ -464,8 +464,6 @@ final class MPVBackend: PlayerBackend {
         timeObserverThrottle.execute {
             self.model.updateWatch(time: self.currentTime)
         }
-
-        self.model.updateTime(self.currentTime!)
     }
 
     private func stopClientUpdates() {


### PR DESCRIPTION
This should circumvent edge cases where videos are marked as watch when they failed to play back.

Fixes #660