### PR TITLE
Color changes to VideoActions

### DIFF
--- a/Shared/Player/Video Details/VideoActions.swift
+++ b/Shared/Player/Video Details/VideoActions.swift
@@ -198,10 +198,10 @@ struct VideoActions: View {
             VStack(spacing: 3) {
                 Image(systemName: systemImage)
                     .frame(width: 20, height: 20)
-                    .foregroundColor(active ? Color("AppRedColor") : .accentColor)
+                    .foregroundColor(active ? Color("AppRedColor") : .primary)
                 if playerActionsButtonLabelStyle.text {
                     Text(name.localized())
-                        .foregroundColor(active ? Color("AppRedColor") : .secondary)
+                        .foregroundColor(active ? Color("AppRedColor") : .primary)
                         .font(.caption2)
                         .allowsTightening(true)
                         .lineLimit(1)


### PR DESCRIPTION
In Dark Mode, the VideoActions button were AppRedColor, and it was not clear when they were active. The inactive color is now .primary, and the active color remains AppRedColor.

### Light Mode
![AD13A89F-4CB9-4E63-87AD-90B00F474796_1_201_a](https://github.com/user-attachments/assets/6ad0e649-df74-44cc-83fd-a74b9f546a91)


### Dark Mode

![ED86CC8E-D1D1-481B-A653-9A14DFB9134B_1_201_a](https://github.com/user-attachments/assets/15813bda-2e15-4da8-9c86-720ce744d037)


I also tried .secondary but in dark mode it just looks off and the buttons kind disappear and are difficult to distinguish from the rest of the text.

![1E3E9AB0-F215-4B23-A673-3D8481681F7F_1_201_a](https://github.com/user-attachments/assets/6922e344-925c-4713-ad37-1f46ec21c417)
