### PR TITLE
Update now playing info when using system controls – Partial fix for 503

### DIFF
--- a/Model/Player/Backends/AVPlayerBackend.swift
+++ b/Model/Player/Backends/AVPlayerBackend.swift
@@ -362,8 +362,11 @@ final class AVPlayerBackend: PlayerBackend {
             self.asset = nil
         }
 
-
         let startPlaying = {
+            #if !os(macOS)
+                try? AVAudioSession.sharedInstance().setActive(true)
+            #endif
+
             self.setRate(self.model.currentRate)
 
             guard let item = self.model.playerItem, self.isAutoplaying(item) else { return }

--- a/Model/Player/Backends/MPVBackend.swift
+++ b/Model/Player/Backends/MPVBackend.swift
@@ -245,6 +245,21 @@ final class MPVBackend: PlayerBackend {
         }
 
         let startPlaying = {
+            #if !os(macOS)
+                do {
+                    try AVAudioSession.sharedInstance().setActive(true)
+
+                    NotificationCenter.default.addObserver(
+                        self,
+                        selector: #selector(self.handleAudioSessionInterruption(_:)),
+                        name: AVAudioSession.interruptionNotification,
+                        object: nil
+                    )
+                } catch {
+                    self.logger.error("Error setting up audio session: \(error)")
+                }
+            #endif
+
             DispatchQueue.main.async { [weak self] in
                 guard let self else {
                     return

--- a/Model/Player/Backends/MPVBackend.swift
+++ b/Model/Player/Backends/MPVBackend.swift
@@ -245,21 +245,6 @@ final class MPVBackend: PlayerBackend {
         }
 
         let startPlaying = {
-            #if !os(macOS)
-                do {
-                    try AVAudioSession.sharedInstance().setActive(true)
-
-                    NotificationCenter.default.addObserver(
-                        self,
-                        selector: #selector(self.handleAudioSessionInterruption(_:)),
-                        name: AVAudioSession.interruptionNotification,
-                        object: nil
-                    )
-                } catch {
-                    self.logger.error("Error setting up audio session: \(error)")
-                }
-            #endif
-
             DispatchQueue.main.async { [weak self] in
                 guard let self else {
                     return

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -23,7 +23,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
             // Configure the audio session for playback
             do {
                 try AVAudioSession.sharedInstance().setCategory(.playback, mode: .moviePlayback)
-                try AVAudioSession.sharedInstance().setActive(true)
             } catch {
                 logger.error("Failed to set audio session category: \(error)")
             }

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -1,9 +1,12 @@
+import AVFoundation
 import Foundation
+import Logging
 import UIKit
 
 final class AppDelegate: UIResponder, UIApplicationDelegate {
     var orientationLock = UIInterfaceOrientationMask.all
 
+    private var logger = Logger(label: "stream.yattee.app.delegalate")
     private(set) static var instance: AppDelegate!
 
     func application(_: UIApplication, supportedInterfaceOrientationsFor _: UIWindow?) -> UIInterfaceOrientationMask {
@@ -12,11 +15,23 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool { // swiftlint:disable:this discouraged_optional_collection
         Self.instance = self
-        #if os(iOS)
-            UIViewController.swizzleHomeIndicatorProperty()
 
+        #if !os(macOS)
+            UIViewController.swizzleHomeIndicatorProperty()
             OrientationTracker.shared.startDeviceOrientationTracking()
+
+            // Configure the audio session for playback
+            do {
+                try AVAudioSession.sharedInstance().setCategory(.playback, mode: .moviePlayback)
+                try AVAudioSession.sharedInstance().setActive(true)
+            } catch {
+                logger.error("Failed to set audio session category: \(error)")
+            }
+
+            // Begin receiving remote control events
+            UIApplication.shared.beginReceivingRemoteControlEvents()
         #endif
+
         return true
     }
 


### PR DESCRIPTION
- update nowPlayingInfo when using system controls
- configure AVAudioSession in AppDelegate, so it has only to be done once and is available right after app start
- listen to RemoteControllEvents right after app start
- partial fix for #503, controls are still not usable but cover art and playback time are displayed and the Airplay button is usable

### Before

![65ADEADE-14DF-43D9-BAC2-55A1BA721EF3_4_5005_c](https://github.com/user-attachments/assets/9c608ac2-bc48-4126-9007-c172549531a0)


### After

![32A6F0EF-F676-4DCE-A74D-8A2BF9FAA79D_4_5005_c](https://github.com/user-attachments/assets/e53e3f6d-d26f-4e97-9097-ef1f6dcbe4a6)
