### PR TITLE
Video Thumbnails: retry 3 times fetching from URL

### DIFF
--- a/Model/ThumbnailsModel.swift
+++ b/Model/ThumbnailsModel.swift
@@ -7,7 +7,7 @@ final class ThumbnailsModel: ObservableObject {
     @Published var unloadable = Set<URL>()
     private var retryCounts = [URL: Int]()
     private let maxRetries = 3
-    private let retryDelay: TimeInterval = 0.25
+    private let retryDelay: TimeInterval = 1.0
 
     func insertUnloadable(_ url: URL) {
         let retries = (retryCounts[url] ?? 0) + 1


### PR DESCRIPTION
This should make it more unlikely that video thumbnails have low quality or the placeholder is shown, when the requested quality could not be fetched first time.