### PR TITLE
iOS: Simplified fullscreen and orientation

### DIFF
--- a/Model/Import Export Settings/Exporters/PlayerSettingsGroupExporter.swift
+++ b/Model/Import Export Settings/Exporters/PlayerSettingsGroupExporter.swift
@@ -44,7 +44,7 @@ final class PlayerSettingsGroupExporter: SettingsGroupExporter {
         #endif
 
         #if os(iOS)
-            export["honorSystemOrientationLock"].bool = Defaults[.honorSystemOrientationLock]
+            export["isOrientationLocked"].bool = Defaults[.isOrientationLocked]
             export["enterFullscreenInLandscape"].bool = Defaults[.enterFullscreenInLandscape]
             export["rotateToLandscapeOnEnterFullScreen"].string = Defaults[.rotateToLandscapeOnEnterFullScreen].rawValue
         #endif

--- a/Model/Import Export Settings/Importers/PlayerSettingsGroupImporter.swift
+++ b/Model/Import Export Settings/Importers/PlayerSettingsGroupImporter.swift
@@ -97,8 +97,8 @@ struct PlayerSettingsGroupImporter {
         #endif
 
         #if os(iOS)
-            if let honorSystemOrientationLock = json["honorSystemOrientationLock"].bool {
-                Defaults[.honorSystemOrientationLock] = honorSystemOrientationLock
+            if let isOrientationLocked = json["isOrientationLocked"].bool {
+                Defaults[.isOrientationLocked] = isOrientationLocked
             }
 
             if let enterFullscreenInLandscape = json["enterFullscreenInLandscape"].bool {

--- a/Shared/Defaults.swift
+++ b/Shared/Defaults.swift
@@ -93,12 +93,9 @@ extension Defaults.Keys {
     static let enableReturnYouTubeDislike = Key<Bool>("enableReturnYouTubeDislike", default: false)
 
     #if os(iOS)
-        static let honorSystemOrientationLock = Key<Bool>("honorSystemOrientationLock", default: true)
+        static let isOrientationLocked = Key<Bool>("isOrientationLocked", default: Constants.isIPhone)
         static let enterFullscreenInLandscape = Key<Bool>("enterFullscreenInLandscape", default: Constants.isIPhone)
-        static let rotateToLandscapeOnEnterFullScreen = Key<FullScreenRotationSetting>(
-            "rotateToLandscapeOnEnterFullScreen",
-            default: Constants.isIPhone ? .landscapeRight : .disabled
-        )
+        static let rotateToLandscapeOnEnterFullScreen = Key<FullScreenRotationSetting>("rotateToLandscapeOnEnterFullScreen", default: .landscapeRight)
     #endif
 
     static let closePiPOnNavigation = Key<Bool>("closePiPOnNavigation", default: false)
@@ -612,26 +609,19 @@ enum PlayerTapGestureAction: String, CaseIterable, Defaults.Serializable {
 }
 
 enum FullScreenRotationSetting: String, CaseIterable, Defaults.Serializable {
-    case disabled
     case landscapeLeft
     case landscapeRight
 
     #if os(iOS)
-        var interaceOrientation: UIInterfaceOrientation {
+        var interfaceOrientation: UIInterfaceOrientation {
             switch self {
             case .landscapeLeft:
                 return .landscapeLeft
             case .landscapeRight:
                 return .landscapeRight
-            default:
-                return .portrait
             }
         }
     #endif
-
-    var isRotating: Bool {
-        self != .disabled
-    }
 }
 
 struct WidgetSettings: Defaults.Serializable {

--- a/Shared/Player/AppleAVPlayerView.swift
+++ b/Shared/Player/AppleAVPlayerView.swift
@@ -17,12 +17,11 @@ import SwiftUI
 
         #if os(iOS)
             func playerViewController(_: AVPlayerViewController, willBeginFullScreenPresentationWithAnimationCoordinator _: UIViewControllerTransitionCoordinator) {
-                guard rotateToLandscapeOnEnterFullScreen.isRotating else { return }
                 if PlayerModel.shared.currentVideoIsLandscape {
                     let delay = PlayerModel.shared.activeBackend == .appleAVPlayer && avPlayerUsesSystemControls ? 0.8 : 0
                     // not sure why but first rotation call is ignore so doing rotate to same orientation first
                     Delay.by(delay) {
-                        let orientation = OrientationTracker.shared.currentDeviceOrientation.isLandscape ? OrientationTracker.shared.currentInterfaceOrientation : self.rotateToLandscapeOnEnterFullScreen.interaceOrientation
+                        let orientation = OrientationTracker.shared.currentDeviceOrientation.isLandscape ? OrientationTracker.shared.currentInterfaceOrientation : self.rotateToLandscapeOnEnterFullScreen.interfaceOrientation
                         Orientation.lockOrientation(.allButUpsideDown, andRotateTo: OrientationTracker.shared.currentInterfaceOrientation)
                         Orientation.lockOrientation(.allButUpsideDown, andRotateTo: orientation)
                     }
@@ -37,8 +36,6 @@ import SwiftUI
                     }
                     if !context.isCancelled {
                         #if os(iOS)
-                            self.player.lockedOrientation = nil
-
                             if Constants.isIPhone {
                                 Orientation.lockOrientation(.allButUpsideDown, andRotateTo: .portrait)
                             }

--- a/Shared/Player/Controls/PlayerControls.swift
+++ b/Shared/Player/Controls/PlayerControls.swift
@@ -389,7 +389,7 @@ struct PlayerControls: View {
 
     #if os(iOS)
         private var lockOrientationButton: some View {
-            button("Lock Rotation", systemImage: player.lockOrientationImage, active: !player.lockedOrientation.isNil, action: player.lockOrientationAction)
+            button("Lock Rotation", systemImage: player.lockOrientationImage, active: player.isOrientationLocked, action: player.lockOrientationAction)
         }
     #endif
 

--- a/Shared/Player/PlayerDragGesture.swift
+++ b/Shared/Player/PlayerDragGesture.swift
@@ -64,11 +64,7 @@ extension VideoPlayerView {
 
                 // Toggle fullscreen on upward drag only when not disabled
                 if verticalDrag < -50 {
-                    if player.playingFullScreen {
-                        player.exitFullScreen(showControls: false)
-                    } else {
-                        player.enterFullScreen()
-                    }
+                    player.toggleFullScreenAction()
                     disableGestureTemporarily()
                     return
                 }

--- a/Shared/Player/Video Details/VideoActions.swift
+++ b/Shared/Player/Video Details/VideoActions.swift
@@ -158,7 +158,7 @@ struct VideoActions: View {
                     actionButton("PiP", systemImage: player.pipImage, active: player.playingInPictureInPicture, action: player.togglePiPAction)
                 #if os(iOS)
                     case .lockOrientation:
-                        actionButton("Lock", systemImage: player.lockOrientationImage, active: player.lockedOrientation != nil, action: player.lockOrientationAction)
+                        actionButton("Lock", systemImage: player.lockOrientationImage, active: player.isOrientationLocked, action: player.lockOrientationAction)
                 #endif
                 case .restart:
                     actionButton("Replay", systemImage: "backward.end.fill", action: player.replayAction)

--- a/Shared/Player/VideoPlayerView.swift
+++ b/Shared/Player/VideoPlayerView.swift
@@ -111,9 +111,6 @@ struct VideoPlayerView: View {
                 .onChange(of: geometry.size) { _ in
                     self.playerSize = geometry.size
                 }
-                .onChange(of: fullScreenDetails) { value in
-                    player.backend.setNeedsDrawing(!value)
-                }
             #if os(iOS)
                 .onChange(of: player.presentingPlayer) { newValue in
                     if newValue {
@@ -127,19 +124,6 @@ struct VideoPlayerView: View {
                         }
                     #endif
                     viewDragOffset = 0
-
-                    Delay.by(0.2) {
-                        orientationModel.configureOrientationUpdatesBasedOnAccelerometer()
-
-                        if let orientationMask = player.lockedOrientation {
-                            Orientation.lockOrientation(
-                                orientationMask,
-                                andRotateTo: orientationMask == .landscapeLeft ? .landscapeLeft : orientationMask == .landscapeRight ? .landscapeRight : .portrait
-                            )
-                        } else {
-                            Orientation.lockOrientation(.allButUpsideDown)
-                        }
-                    }
                 }
                 .onAnimationCompleted(for: viewDragOffset) {
                     guard !dragGestureState else { return }
@@ -313,11 +297,14 @@ struct VideoPlayerView: View {
                                 playerSize: player.playerSize,
                                 fullScreen: fullScreenDetails
                             ))
+                            #if os(macOS)
+                            // TODO: Check whether this is needed on macOS.
                             .onDisappear {
                                 if player.presentingPlayer {
                                     player.setNeedsDrawing(true)
                                 }
                             }
+                            #endif
                             .id(player.currentVideo?.cacheKey)
                             .transition(.opacity)
                         } else {

--- a/Shared/Settings/BrowsingSettings.swift
+++ b/Shared/Settings/BrowsingSettings.swift
@@ -10,6 +10,7 @@ struct BrowsingSettings: View {
     @Default(.showUnwatchedFeedBadges) private var showUnwatchedFeedBadges
     @Default(.keepChannelsWithUnwatchedFeedOnTop) private var keepChannelsWithUnwatchedFeedOnTop
     #if os(iOS)
+        @Default(.enterFullscreenInLandscape) private var enterFullscreenInLandscape
         @Default(.lockPortraitWhenBrowsing) private var lockPortraitWhenBrowsing
         @Default(.showDocuments) private var showDocuments
     #endif
@@ -161,14 +162,18 @@ struct BrowsingSettings: View {
             #if os(iOS)
                 Toggle("Show Documents", isOn: $showDocuments)
 
-                Toggle("Lock portrait mode", isOn: $lockPortraitWhenBrowsing)
-                    .onChange(of: lockPortraitWhenBrowsing) { lock in
-                        if lock {
-                            Orientation.lockOrientation(.portrait, andRotateTo: .portrait)
-                        } else {
-                            Orientation.lockOrientation(.allButUpsideDown)
+                if Constants.isIPad {
+                    Toggle("Lock portrait mode", isOn: $lockPortraitWhenBrowsing)
+                        .onChange(of: lockPortraitWhenBrowsing) { lock in
+                            if lock {
+                                enterFullscreenInLandscape = true
+                                Orientation.lockOrientation(.portrait, andRotateTo: .portrait)
+                            } else {
+                                enterFullscreenInLandscape = false
+                                Orientation.lockOrientation(.allButUpsideDown)
+                            }
                         }
-                    }
+                }
             #endif
 
             if !accounts.isEmpty {

--- a/Shared/Settings/PlayerSettings.swift
+++ b/Shared/Settings/PlayerSettings.swift
@@ -18,8 +18,8 @@ struct PlayerSettings: View {
     @Default(.pauseOnHidingPlayer) private var pauseOnHidingPlayer
     @Default(.closeVideoOnEOF) private var closeVideoOnEOF
     #if os(iOS)
-        @Default(.honorSystemOrientationLock) private var honorSystemOrientationLock
         @Default(.enterFullscreenInLandscape) private var enterFullscreenInLandscape
+        @Default(.lockPortraitWhenBrowsing) private var lockPortraitWhenBrowsing
         @Default(.rotateToLandscapeOnEnterFullScreen) private var rotateToLandscapeOnEnterFullScreen
     #endif
     @Default(.closePiPOnNavigation) private var closePiPOnNavigation
@@ -87,7 +87,7 @@ struct PlayerSettings: View {
                 }
                 pauseOnHidingPlayerToggle
                 closeVideoOnEOFToggle
-                #if !os(tvOS)
+                #if os(macOS)
                     exitFullscreenOnEOFToggle
                 #endif
                 #if !os(macOS)
@@ -202,11 +202,12 @@ struct PlayerSettings: View {
             #endif
 
             #if os(iOS)
-                Section(header: SettingsHeader(text: "Orientation".localized())) {
-                    if idiom == .pad {
+                Section(header: SettingsHeader(text: "Fullscreen".localized())) {
+                    if Constants.isIPad {
                         enterFullscreenInLandscapeToggle
                     }
-                    honorSystemOrientationLockToggle
+
+                    exitFullscreenOnEOFToggle
                     rotateToLandscapeOnEnterFullScreenPicker
                 }
             #endif
@@ -318,20 +319,15 @@ struct PlayerSettings: View {
     #endif
 
     #if os(iOS)
-        private var honorSystemOrientationLockToggle: some View {
-            Toggle("Honor orientation lock", isOn: $honorSystemOrientationLock)
-                .disabled(!enterFullscreenInLandscape)
-        }
-
         private var enterFullscreenInLandscapeToggle: some View {
-            Toggle("Enter fullscreen in landscape", isOn: $enterFullscreenInLandscape)
+            Toggle("Enter fullscreen in landscape orientation", isOn: $enterFullscreenInLandscape)
+                .disabled(lockPortraitWhenBrowsing)
         }
 
         private var rotateToLandscapeOnEnterFullScreenPicker: some View {
-            Picker("Rotate when entering fullscreen on landscape video", selection: $rotateToLandscapeOnEnterFullScreen) {
+            Picker("Default orientation", selection: $rotateToLandscapeOnEnterFullScreen) {
                 Text("Landscape left").tag(FullScreenRotationSetting.landscapeLeft)
                 Text("Landscape right").tag(FullScreenRotationSetting.landscapeRight)
-                Text("No rotation").tag(FullScreenRotationSetting.disabled)
             }
             .modifier(SettingsPickerModifier())
         }

--- a/Yattee.xcodeproj/project.pbxproj
+++ b/Yattee.xcodeproj/project.pbxproj
@@ -4366,7 +4366,9 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UIRequiresFullScreen = YES;
 				INFOPLIST_KEY_UIStatusBarHidden = NO;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UIStatusBarStyle = "";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4415,7 +4417,9 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UIRequiresFullScreen = YES;
 				INFOPLIST_KEY_UIStatusBarHidden = NO;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UIStatusBarStyle = "";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -1,16 +1,17 @@
 import AVFoundation
+import Defaults
 import Foundation
 import Logging
 import UIKit
 
 final class AppDelegate: UIResponder, UIApplicationDelegate {
-    var orientationLock = UIInterfaceOrientationMask.all
+    var orientationLock = UIInterfaceOrientationMask.allButUpsideDown
 
-    private var logger = Logger(label: "stream.yattee.app.delegalate")
+    private var logger = Logger(label: "stream.yattee.app.delegate")
     private(set) static var instance: AppDelegate!
 
     func application(_: UIApplication, supportedInterfaceOrientationsFor _: UIWindow?) -> UIInterfaceOrientationMask {
-        orientationLock
+        return orientationLock
     }
 
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool { // swiftlint:disable:this discouraged_optional_collection
@@ -19,6 +20,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         #if !os(macOS)
             UIViewController.swizzleHomeIndicatorProperty()
             OrientationTracker.shared.startDeviceOrientationTracking()
+            OrientationModel.shared.startOrientationUpdates()
 
             // Configure the audio session for playback
             do {

--- a/iOS/OrientationModel.swift
+++ b/iOS/OrientationModel.swift
@@ -1,10 +1,12 @@
 import Defaults
 import Foundation
+import Logging
 import Repeat
 import SwiftUI
 
 final class OrientationModel {
     static var shared = OrientationModel()
+    let logger = Logger(label: "stream.yattee.orientation.model")
 
     var orientation = UIInterfaceOrientation.portrait
     var lastOrientation: UIInterfaceOrientation?
@@ -13,79 +15,69 @@ final class OrientationModel {
 
     private var player = PlayerModel.shared
 
-    func configureOrientationUpdatesBasedOnAccelerometer() {
-        let currentOrientation = OrientationTracker.shared.currentInterfaceOrientation
-        if currentOrientation.isLandscape,
-           Defaults[.enterFullscreenInLandscape],
-           !Defaults[.honorSystemOrientationLock],
-           !player.playingFullScreen,
-           !player.currentItem.isNil,
-           player.lockedOrientation.isNil || player.lockedOrientation!.contains(.landscape),
-           !player.playingInPictureInPicture,
-           player.presentingPlayer
-        {
-            DispatchQueue.main.async {
-                self.player.controls.presentingControls = false
-                self.player.enterFullScreen(showControls: false)
-            }
-
-            player.onPresentPlayer.append {
-                Orientation.lockOrientation(.allButUpsideDown, andRotateTo: currentOrientation)
-            }
-        }
-
+    func startOrientationUpdates() {
+        // Ensure the orientation observer is active
         orientationObserver = NotificationCenter.default.addObserver(
             forName: OrientationTracker.deviceOrientationChangedNotification,
             object: nil,
             queue: .main
         ) { _ in
-            guard !Defaults[.honorSystemOrientationLock],
-                  self.player.presentingPlayer,
-                  !self.player.playingInPictureInPicture,
-                  self.player.lockedOrientation.isNil
+            self.logger.info("Notification received: Device orientation changed.")
+
+            // We only allow .portrait and are not showing the player
+            guard (!self.player.presentingPlayer && !Defaults[.lockPortraitWhenBrowsing]) || self.player.presentingPlayer
             else {
                 return
             }
 
             let orientation = OrientationTracker.shared.currentInterfaceOrientation
+            self.logger.info("Current interface orientation: \(orientation)")
 
-            guard self.lastOrientation != orientation else {
+            // Always update lastOrientation to keep track of the latest state
+            if self.lastOrientation != orientation {
+                self.lastOrientation = orientation
+                self.logger.info("Orientation changed to: \(orientation)")
+            } else {
+                self.logger.info("Orientation has not changed.")
+            }
+
+            // Only take action if the player is active and presenting
+            guard (!self.player.isOrientationLocked && !self.player.playingInPictureInPicture) || (!Defaults[.lockPortraitWhenBrowsing] && !self.player.presentingPlayer) || (!Defaults[.lockPortraitWhenBrowsing] && self.player.presentingPlayer && !self.player.isOrientationLocked)
+            else {
+                self.logger.info("Only updating orientation without actions.")
                 return
             }
 
-            self.lastOrientation = orientation
-
             DispatchQueue.main.async {
-                guard Defaults[.enterFullscreenInLandscape],
-                      self.player.presentingPlayer
-                else {
-                    return
-                }
-
                 self.orientationDebouncer.callback = {
                     DispatchQueue.main.async {
                         if orientation.isLandscape {
-                            self.player.controls.presentingControls = false
-                            self.player.enterFullScreen(showControls: false)
+                            if Defaults[.enterFullscreenInLandscape], self.player.presentingPlayer {
+                                self.logger.info("Entering fullscreen because orientation is landscape.")
+                                self.player.controls.presentingControls = false
+                                self.player.enterFullScreen(showControls: false)
+                            }
                             Orientation.lockOrientation(OrientationTracker.shared.currentInterfaceOrientationMask, andRotateTo: orientation)
                         } else {
-                            self.player.exitFullScreen(showControls: false)
-                            Orientation.lockOrientation(.allButUpsideDown, andRotateTo: .portrait)
+                            self.logger.info("Exiting fullscreen because orientation is portrait.")
+                            if self.player.playingFullScreen {
+                                self.player.exitFullScreen(showControls: false)
+                            }
+                            if Defaults[.lockPortraitWhenBrowsing] {
+                                Orientation.lockOrientation(.portrait, andRotateTo: .portrait)
+                            } else {
+                                Orientation.lockOrientation(OrientationTracker.shared.currentInterfaceOrientationMask, andRotateTo: orientation)
+                            }
                         }
                     }
                 }
-
                 self.orientationDebouncer.call()
             }
         }
     }
 
-    func stopOrientationUpdates() {
-        guard let observer = orientationObserver else { return }
-        NotificationCenter.default.removeObserver(observer)
-    }
-
     func lockOrientation(_ orientation: UIInterfaceOrientationMask, andRotateTo rotateOrientation: UIInterfaceOrientation? = nil) {
+        logger.info("Locking orientation to: \(orientation), rotating to: \(String(describing: rotateOrientation)).")
         if let rotateOrientation {
             self.orientation = rotateOrientation
             lastOrientation = rotateOrientation


### PR DESCRIPTION
## General
I revamped and simplified the fullscreen and orientation handling.
### Settings

- In the player settings, the subsection **Orientation** has been renamed to **Fullscreen**.
- The option _Honor device orientation_ has been completely removed and won't be used anymore (more on that later).
- _Default orientation_ only has the values _Landscape right_ and _Landscape left_; _disabled_ has been removed.
- _Exit on Fullscreen_ is now in this section.

### Fullscreen handling

- Fullscreen in portrait is not possible anymore.
- Locking video fullscreen rotation is handled by the player's orientation lock.
- Player's rotation lock takes prevalence over system orientation lock for video playback.
- Fullscreen is always possible via buttons or swipe action (PR #778).
- _Default orientation: will be applied when fullscreen is initiated via gesture or button.
- When switching fullscreen via button or gesture, if rotation lock is enabled, the player will be locked to the fullscreen orientation.
- The only way to restrict the app from entering video fullscreen when rotated to any landscape orientation is by enabling orientation lock in the player.
- Since this is a new property, it is on by default. It will be stored in the defaults `isOrientationLocked` and is available across app restarts.
- When the user toggles the orientation lock, the state will be saved and is loaded when the app.
- Remove return from fullscreen hack (PR #772) since the app will now stay in fullscreen when orientation lock is enabled and returns from background.

## iPhone

### Settings
On iPhone, the option _Lock to portrait_ has been removed from the settings. It is now always true. IMHO, there is no reason to provide this option on iPhones. Even an iPhone Pro Max' screen is not big enough to make the UI usable. Moreover, I took a page out of YouTube's playbook, the YouTube app for iPhone is also locked to Portrait.

#### Screenshot iPhone

![4155F359-F433-41B3-888F-3B0C047E9EDB_1_201_a](https://github.com/user-attachments/assets/62ae80f5-89cb-4877-b3ff-e3982e51f4b3)

### Orientation handling
The orientation can only change:
- while the player is visible and a change to fullscreen is initiated

## iPad

###Settings
On iPad the option _Lock to portrait_ is still available. But if enabled, the option _Enter fullscreen in landscape orientation_ will automatically set to `true` and the toggle itself is disabled. This gives a unified experience on iPhone and iPad when the app is locked to portrait.

#### Screenshot iPad

![63C70AB7-B005-468A-BE8B-7E7C72393B6C_4_5005_c](https://github.com/user-attachments/assets/dbdcf761-7d44-4454-bae7-ff9078e45c10)

### Orientation handling

The orientation can only change:

1. Orientation is locked to portrait and **player orientation lock is disabled**: While the player is visible and a change to fullscreen is initiated – enters fullscreen.
2. Orientation is unlocked and `enterFullscreenInLandscape = false`: entire app – but never enters fullscreen on rotation.
3. Orientation is unlocked and `enterFullscreenInLandscape = true`and **player orientation lock is disabled** : entire app – enters fullscreen on rotation from portrait to landscape while player is visible.


## Related issues

- fixes #675
- closes #456
