### PR TITLE
player controls: add background opacity selection

### DIFF
--- a/Model/Import Export Settings/Exporters/ControlsSettingsGroupExporter.swift
+++ b/Model/Import Export Settings/Exporters/ControlsSettingsGroupExporter.swift
@@ -10,6 +10,7 @@ final class ConstrolsSettingsGroupExporter: SettingsGroupExporter {
             "seekGestureSpeed": Defaults[.seekGestureSpeed],
             "playerControlsLayout": Defaults[.playerControlsLayout].rawValue,
             "fullScreenPlayerControlsLayout": Defaults[.fullScreenPlayerControlsLayout].rawValue,
+            "playerControlsBackgroundOpacity": Defaults[.playerControlsBackgroundOpacity],
             "systemControlsCommands": Defaults[.systemControlsCommands].rawValue,
             "buttonBackwardSeekDuration": Defaults[.buttonBackwardSeekDuration],
             "buttonForwardSeekDuration": Defaults[.buttonForwardSeekDuration],

--- a/Model/Import Export Settings/Importers/ControlsSettingsGroupImporter.swift
+++ b/Model/Import Export Settings/Importers/ControlsSettingsGroupImporter.swift
@@ -33,6 +33,10 @@ struct ConstrolsSettingsGroupImporter {
             Defaults[.fullScreenPlayerControlsLayout] = fullScreenPlayerControlsLayout
         }
 
+        if let playerControlsBackgroundOpacity = json["playerControlsBackgroundOpacity"].double {
+            Defaults[.playerControlsBackgroundOpacity] = playerControlsBackgroundOpacity
+        }
+
         if let systemControlsCommandsString = json["systemControlsCommands"].string,
            let systemControlsCommands = SystemControlsCommands(rawValue: systemControlsCommandsString)
         {

--- a/Shared/Defaults.swift
+++ b/Shared/Defaults.swift
@@ -134,6 +134,7 @@ extension Defaults.Keys {
 
     static let playerControlsLayout = Key<PlayerControlsLayout>("playerControlsLayout", default: playerControlsLayoutDefault)
     static let fullScreenPlayerControlsLayout = Key<PlayerControlsLayout>("fullScreenPlayerControlsLayout", default: fullScreenPlayerControlsLayoutDefault)
+    static let playerControlsBackgroundOpacity = Key<Double>("playerControlsBackgroundOpacity", default: 0.2)
 
     static let systemControlsCommands = Key<SystemControlsCommands>("systemControlsCommands", default: .restartAndAdvanceToNext)
 

--- a/Shared/Player/Controls/PlayerControls.swift
+++ b/Shared/Player/Controls/PlayerControls.swift
@@ -29,6 +29,7 @@ struct PlayerControls: View {
 
     @Default(.playerControlsLayout) private var regularPlayerControlsLayout
     @Default(.fullScreenPlayerControlsLayout) private var fullScreenPlayerControlsLayout
+    @Default(.playerControlsBackgroundOpacity) private var playerControlsBackgroundOpacity
     @Default(.buttonBackwardSeekDuration) private var buttonBackwardSeekDuration
     @Default(.buttonForwardSeekDuration) private var buttonForwardSeekDuration
 
@@ -270,6 +271,9 @@ struct PlayerControls: View {
                     }
                 } else if player.videoForDisplay == nil {
                     Color.black
+                } else if model.presentingControls {
+                    Color.black.opacity(playerControlsBackgroundOpacity)
+                        .edgesIgnoringSafeArea(.all)
                 }
             }
         }

--- a/Shared/Settings/PlayerControlsSettings.swift
+++ b/Shared/Settings/PlayerControlsSettings.swift
@@ -38,6 +38,7 @@ struct PlayerControlsSettings: View {
     @Default(.playerControlsAdvanceToNextEnabled) private var playerControlsAdvanceToNextEnabled
     @Default(.playerControlsPlaybackModeEnabled) private var playerControlsPlaybackModeEnabled
     @Default(.playerControlsMusicModeEnabled) private var playerControlsMusicModeEnabled
+    @Default(.playerControlsBackgroundOpacity) private var playerControlsBackgroundOpacity
 
     private var player = PlayerModel.shared
 
@@ -76,6 +77,8 @@ struct PlayerControlsSettings: View {
                 playerControlsLayoutPicker
                 SettingsHeader(text: "Fullscreen size".localized(), secondary: true)
                 fullScreenPlayerControlsLayoutPicker
+                SettingsHeader(text: "Background opacity".localized(), secondary: true)
+                playerControlsBackgroundOpacityPicker
             }
         #endif
 
@@ -197,6 +200,15 @@ struct PlayerControlsSettings: View {
         Picker("Fullscreen size", selection: $fullScreenPlayerControlsLayout) {
             ForEach(PlayerControlsLayout.allCases.filter(\.available), id: \.self) { layout in
                 Text(layout.description).tag(layout.rawValue)
+            }
+        }
+        .modifier(SettingsPickerModifier())
+    }
+
+    private var playerControlsBackgroundOpacityPicker: some View {
+        Picker("Background opacity", selection: $playerControlsBackgroundOpacity) {
+            ForEach(Array(stride(from: 0.0, through: 1.0, by: 0.1)), id: \.self) { value in
+                Text("\(Int(value * 100))%").tag(value)
             }
         }
         .modifier(SettingsPickerModifier())


### PR DESCRIPTION
Users can now set the background opacity for the player controls:

before:

![E6340F24-65E9-47C7-A4F3-2869811A7256_1_201_a](https://github.com/user-attachments/assets/968db531-8e66-40df-bef0-6ebf79f21490)

after (with default value 0.2)

![77F3D50B-3251-4B50-BCCB-C85775EAA3D1_1_201_a](https://github.com/user-attachments/assets/853960ab-9997-45f7-96ff-abd9fc12b7e1)

- fixes #488