### PR TITLE
Orientation/Fullscreen fixes and cleanup

### DIFF
--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -136,8 +136,9 @@ final class PlayerModel: ObservableObject {
             }
         }
 
-        @Default(.rotateToLandscapeOnEnterFullScreen) private var rotateToLandscapeOnEnterFullScreen
-        @Default(.lockPortraitWhenBrowsing) private var lockPortraitWhenBrowsing
+        @Default(.rotateToLandscapeOnEnterFullScreen) var rotateToLandscapeOnEnterFullScreen
+        @Default(.lockPortraitWhenBrowsing) var lockPortraitWhenBrowsing
+        var fullscreenInitiatedByButton = false
     #endif
 
     @Published var currentChapterIndex: Int?
@@ -1150,6 +1151,7 @@ final class PlayerModel: ObservableObject {
         #if os(iOS)
             if playingFullScreen {
                 if activeBackend == .appleAVPlayer, avPlayerUsesSystemControls {
+                    fullscreenInitiatedByButton = initiatedByButton
                     avPlayerBackend.controller.enterFullScreen(animated: true)
                     return
                 }
@@ -1177,7 +1179,7 @@ final class PlayerModel: ObservableObject {
                     avPlayerBackend.controller.dismiss(animated: true)
                     return
                 }
-                if Defaults[.lockPortraitWhenBrowsing] {
+                if lockPortraitWhenBrowsing {
                     lockedOrientation = UIInterfaceOrientationMask.portrait
                 }
                 let rotationOrientation = lockPortraitWhenBrowsing ? UIInterfaceOrientation.portrait : nil

--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -568,7 +568,7 @@ final class PlayerModel: ObservableObject {
                 if lockPortraitWhenBrowsing {
                     Orientation.lockOrientation(.portrait, andRotateTo: .portrait)
                 } else {
-                    Orientation.lockOrientation(.allButUpsideDown)
+                    Orientation.lockOrientation(.all)
                 }
             #endif
         }
@@ -822,7 +822,7 @@ final class PlayerModel: ObservableObject {
             } else {
                 isOrientationLocked = false
                 lockedOrientation = nil
-                Orientation.lockOrientation(.allButUpsideDown)
+                Orientation.lockOrientation(.all)
             }
         }
     #endif
@@ -1167,7 +1167,7 @@ final class PlayerModel: ObservableObject {
                     Orientation.lockOrientation(
                         isOrientationLocked
                             ? (lockOrientation == .landscapeRight ? .landscapeRight : .landscapeLeft)
-                            : .landscape,
+                            : .all,
                         andRotateTo: orientation
                     )
                 }
@@ -1181,7 +1181,7 @@ final class PlayerModel: ObservableObject {
                     lockedOrientation = UIInterfaceOrientationMask.portrait
                 }
                 let rotationOrientation = lockPortraitWhenBrowsing ? UIInterfaceOrientation.portrait : nil
-                Orientation.lockOrientation(lockPortraitWhenBrowsing ? .portrait : .allButUpsideDown, andRotateTo: rotationOrientation)
+                Orientation.lockOrientation(lockPortraitWhenBrowsing ? .portrait : .all, andRotateTo: rotationOrientation)
             }
         #endif
     }

--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -137,6 +137,7 @@ final class PlayerModel: ObservableObject {
         }
 
         @Default(.rotateToLandscapeOnEnterFullScreen) private var rotateToLandscapeOnEnterFullScreen
+        @Default(.lockPortraitWhenBrowsing) private var lockPortraitWhenBrowsing
     #endif
 
     @Published var currentChapterIndex: Int?
@@ -209,7 +210,7 @@ final class PlayerModel: ObservableObject {
         #if os(iOS)
             isOrientationLocked = Defaults[.isOrientationLocked]
 
-            if isOrientationLocked, Defaults[.lockPortraitWhenBrowsing] {
+            if isOrientationLocked, lockPortraitWhenBrowsing {
                 lockedOrientation = UIInterfaceOrientationMask.portrait
                 Orientation.lockOrientation(.portrait, andRotateTo: .portrait)
             } else if isOrientationLocked {
@@ -564,7 +565,7 @@ final class PlayerModel: ObservableObject {
 
         if !presentingPlayer {
             #if os(iOS)
-                if Defaults[.lockPortraitWhenBrowsing] {
+                if lockPortraitWhenBrowsing {
                     Orientation.lockOrientation(.portrait, andRotateTo: .portrait)
                 } else {
                     Orientation.lockOrientation(.allButUpsideDown)
@@ -1155,10 +1156,20 @@ final class PlayerModel: ObservableObject {
                 let lockOrientation = rotateToLandscapeOnEnterFullScreen.interfaceOrientation
                 if currentVideoIsLandscape {
                     if initiatedByButton {
-                        Orientation.lockOrientation(self.isOrientationLocked ? (lockOrientation == .landscapeRight ? .landscapeRight : .landscapeLeft) : .landscape)
+                        Orientation.lockOrientation(isOrientationLocked
+                            ? (lockOrientation == .landscapeRight ? .landscapeRight : .landscapeLeft)
+                            : .landscape)
                     }
-                    let orientation = OrientationTracker.shared.currentDeviceOrientation.isLandscape ? OrientationTracker.shared.currentInterfaceOrientation : self.rotateToLandscapeOnEnterFullScreen.interfaceOrientation
-                    Orientation.lockOrientation(self.isOrientationLocked ? (lockOrientation == .landscapeRight ? .landscapeRight : .landscapeLeft) : .landscape, andRotateTo: orientation)
+                    let orientation = OrientationTracker.shared.currentDeviceOrientation.isLandscape
+                        ? OrientationTracker.shared.currentInterfaceOrientation
+                        : rotateToLandscapeOnEnterFullScreen.interfaceOrientation
+
+                    Orientation.lockOrientation(
+                        isOrientationLocked
+                            ? (lockOrientation == .landscapeRight ? .landscapeRight : .landscapeLeft)
+                            : .landscape,
+                        andRotateTo: orientation
+                    )
                 }
             } else {
                 if activeBackend == .appleAVPlayer, avPlayerUsesSystemControls {
@@ -1169,8 +1180,8 @@ final class PlayerModel: ObservableObject {
                 if Defaults[.lockPortraitWhenBrowsing] {
                     lockedOrientation = UIInterfaceOrientationMask.portrait
                 }
-                let rotationOrientation = Defaults[.lockPortraitWhenBrowsing] ? UIInterfaceOrientation.portrait : nil
-                Orientation.lockOrientation(Defaults[.lockPortraitWhenBrowsing] ? .portrait : .allButUpsideDown, andRotateTo: rotationOrientation)
+                let rotationOrientation = lockPortraitWhenBrowsing ? UIInterfaceOrientation.portrait : nil
+                Orientation.lockOrientation(lockPortraitWhenBrowsing ? .portrait : .allButUpsideDown, andRotateTo: rotationOrientation)
             }
         #endif
     }

--- a/Shared/Player/AppleAVPlayerView.swift
+++ b/Shared/Player/AppleAVPlayerView.swift
@@ -22,8 +22,8 @@ import SwiftUI
                     // not sure why but first rotation call is ignore so doing rotate to same orientation first
                     Delay.by(delay) {
                         let orientation = OrientationTracker.shared.currentDeviceOrientation.isLandscape ? OrientationTracker.shared.currentInterfaceOrientation : self.rotateToLandscapeOnEnterFullScreen.interfaceOrientation
-                        Orientation.lockOrientation(.allButUpsideDown, andRotateTo: OrientationTracker.shared.currentInterfaceOrientation)
-                        Orientation.lockOrientation(.allButUpsideDown, andRotateTo: orientation)
+                        Orientation.lockOrientation(.all, andRotateTo: OrientationTracker.shared.currentInterfaceOrientation)
+                        Orientation.lockOrientation(.all, andRotateTo: orientation)
                     }
                 }
             }
@@ -37,7 +37,7 @@ import SwiftUI
                     if !context.isCancelled {
                         #if os(iOS)
                             if Constants.isIPhone {
-                                Orientation.lockOrientation(.allButUpsideDown, andRotateTo: .portrait)
+                                Orientation.lockOrientation(.all, andRotateTo: .portrait)
                             }
 
                             if wasPlaying {

--- a/Shared/Settings/BrowsingSettings.swift
+++ b/Shared/Settings/BrowsingSettings.swift
@@ -170,7 +170,7 @@ struct BrowsingSettings: View {
                                 Orientation.lockOrientation(.portrait, andRotateTo: .portrait)
                             } else {
                                 enterFullscreenInLandscape = false
-                                Orientation.lockOrientation(.allButUpsideDown)
+                                Orientation.lockOrientation(.all)
                             }
                         }
                 }

--- a/Shared/YatteeApp.swift
+++ b/Shared/YatteeApp.swift
@@ -211,7 +211,7 @@ struct YatteeApp: App {
                         let rotationOrientation =
                             OrientationTracker.shared.currentDeviceOrientation.rawValue == 4 ? UIInterfaceOrientation.landscapeRight :
                             (OrientationTracker.shared.currentDeviceOrientation.rawValue == 3 ? UIInterfaceOrientation.landscapeLeft : UIInterfaceOrientation.portrait)
-                        Orientation.lockOrientation(.allButUpsideDown, andRotateTo: rotationOrientation)
+                        Orientation.lockOrientation(.all, andRotateTo: rotationOrientation)
                     }
                 }
             #endif

--- a/Yattee.xcodeproj/project.pbxproj
+++ b/Yattee.xcodeproj/project.pbxproj
@@ -4367,8 +4367,7 @@
 				INFOPLIST_KEY_UIRequiresFullScreen = YES;
 				INFOPLIST_KEY_UIStatusBarHidden = NO;
 				INFOPLIST_KEY_UIStatusBarStyle = "";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4418,8 +4417,7 @@
 				INFOPLIST_KEY_UIRequiresFullScreen = YES;
 				INFOPLIST_KEY_UIStatusBarHidden = NO;
 				INFOPLIST_KEY_UIStatusBarStyle = "";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -5,7 +5,7 @@ import Logging
 import UIKit
 
 final class AppDelegate: UIResponder, UIApplicationDelegate {
-    var orientationLock = UIInterfaceOrientationMask.allButUpsideDown
+    var orientationLock = UIInterfaceOrientationMask.all
 
     private var logger = Logger(label: "stream.yattee.app.delegate")
     private(set) static var instance: AppDelegate!

--- a/iOS/Orientation.swift
+++ b/iOS/Orientation.swift
@@ -34,7 +34,7 @@ enum Orientation {
             let rotateOrientationMask = rotateOrientation == .portrait ? UIInterfaceOrientationMask.portrait :
                 rotateOrientation == .landscapeLeft ? .landscapeLeft :
                 rotateOrientation == .landscapeRight ? .landscapeRight :
-                .allButUpsideDown
+                .all
 
             windowScene.requestGeometryUpdate(.iOS(interfaceOrientations: rotateOrientationMask)) { error in
                 print("denied rotation \(error)")

--- a/iOS/Orientation.swift
+++ b/iOS/Orientation.swift
@@ -1,5 +1,4 @@
 import CoreMotion
-import Defaults
 import Logging
 import UIKit
 

--- a/iOS/OrientationModel.swift
+++ b/iOS/OrientationModel.swift
@@ -13,6 +13,9 @@ final class OrientationModel {
     var orientationDebouncer = Debouncer(.milliseconds(300))
     var orientationObserver: Any?
 
+    @Default(.lockPortraitWhenBrowsing) private var lockPortraitWhenBrowsing
+    @Default(.enterFullscreenInLandscape) private var enterFullscreenInLandscape
+
     private var player = PlayerModel.shared
 
     func startOrientationUpdates() {
@@ -25,7 +28,7 @@ final class OrientationModel {
             self.logger.info("Notification received: Device orientation changed.")
 
             // We only allow .portrait and are not showing the player
-            guard (!self.player.presentingPlayer && !Defaults[.lockPortraitWhenBrowsing]) || self.player.presentingPlayer
+            guard (!self.player.presentingPlayer && !self.lockPortraitWhenBrowsing) || self.player.presentingPlayer
             else {
                 return
             }
@@ -42,7 +45,7 @@ final class OrientationModel {
             }
 
             // Only take action if the player is active and presenting
-            guard (!self.player.isOrientationLocked && !self.player.playingInPictureInPicture) || (!Defaults[.lockPortraitWhenBrowsing] && !self.player.presentingPlayer) || (!Defaults[.lockPortraitWhenBrowsing] && self.player.presentingPlayer && !self.player.isOrientationLocked)
+            guard (!self.player.isOrientationLocked && !self.player.playingInPictureInPicture) || (!self.lockPortraitWhenBrowsing && !self.player.presentingPlayer) || (!self.lockPortraitWhenBrowsing && self.player.presentingPlayer && !self.player.isOrientationLocked)
             else {
                 self.logger.info("Only updating orientation without actions.")
                 return
@@ -52,7 +55,7 @@ final class OrientationModel {
                 self.orientationDebouncer.callback = {
                     DispatchQueue.main.async {
                         if orientation.isLandscape {
-                            if Defaults[.enterFullscreenInLandscape], self.player.presentingPlayer {
+                            if self.enterFullscreenInLandscape, self.player.presentingPlayer {
                                 self.logger.info("Entering fullscreen because orientation is landscape.")
                                 self.player.controls.presentingControls = false
                                 self.player.enterFullScreen(showControls: false)
@@ -63,7 +66,7 @@ final class OrientationModel {
                             if self.player.playingFullScreen {
                                 self.player.exitFullScreen(showControls: false)
                             }
-                            if Defaults[.lockPortraitWhenBrowsing] {
+                            if self.lockPortraitWhenBrowsing {
                                 Orientation.lockOrientation(.portrait, andRotateTo: .portrait)
                             } else {
                                 Orientation.lockOrientation(OrientationTracker.shared.currentInterfaceOrientationMask, andRotateTo: orientation)


### PR DESCRIPTION
- fixes an issue where the fullscreen would rotate twice, if rotated to the opposite of the default landscape rotation.
- the new Fullscreen logic is now also used for AVPlayer