### PR TITLE
Retry loading video before presenting error

### DIFF
--- a/Model/Import Export Settings/Exporters/AdvancedSettingsGroupExporter.swift
+++ b/Model/Import Export Settings/Exporters/AdvancedSettingsGroupExporter.swift
@@ -5,6 +5,7 @@ final class AdvancedSettingsGroupExporter: SettingsGroupExporter {
     override var globalJSON: JSON {
         [
             "showPlayNowInBackendContextMenu": Defaults[.showPlayNowInBackendContextMenu],
+            "videoLoadingRetryCount": Defaults[.videoLoadingRetryCount],
             "showMPVPlaybackStats": Defaults[.showMPVPlaybackStats],
             "mpvEnableLogging": Defaults[.mpvEnableLogging],
             "mpvCacheSecs": Defaults[.mpvCacheSecs],

--- a/Model/Import Export Settings/Importers/AdvancedSettingsGroupImporter.swift
+++ b/Model/Import Export Settings/Importers/AdvancedSettingsGroupImporter.swift
@@ -9,6 +9,10 @@ struct AdvancedSettingsGroupImporter {
             Defaults[.showPlayNowInBackendContextMenu] = showPlayNowInBackendContextMenu
         }
 
+        if let videoLoadingRetryCount = json["videoLoadingRetryCount"].int {
+            Defaults[.videoLoadingRetryCount] = videoLoadingRetryCount
+        }
+
         if let showMPVPlaybackStats = json["showMPVPlaybackStats"].bool {
             Defaults[.showMPVPlaybackStats] = showMPVPlaybackStats
         }

--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -201,6 +201,9 @@ final class PlayerModel: ObservableObject {
     var rateToRestore: Float?
     private var remoteCommandCenterConfigured = false
 
+    // Used in the PlayerModel extension in PlayerQueue
+    var retryAttempts = [String: Int]()
+
     #if os(macOS)
         var keyPressMonitor: Any?
     #endif

--- a/Shared/Defaults.swift
+++ b/Shared/Defaults.swift
@@ -358,6 +358,7 @@ extension Defaults.Keys {
     // MARK: Group - Advanced
 
     static let showPlayNowInBackendContextMenu = Key<Bool>("showPlayNowInBackendContextMenu", default: false)
+    static let videoLoadingRetryCount = Key<Int>("videoLoadingRetryCount", default: 10)
 
     static let showMPVPlaybackStats = Key<Bool>("showMPVPlaybackStats", default: false)
     static let mpvEnableLogging = Key<Bool>("mpvEnableLogging", default: false)

--- a/Shared/Settings/AdvancedSettings.swift
+++ b/Shared/Settings/AdvancedSettings.swift
@@ -14,6 +14,7 @@ struct AdvancedSettings: View {
     @Default(.showCacheStatus) private var showCacheStatus
     @Default(.feedCacheSize) private var feedCacheSize
     @Default(.showPlayNowInBackendContextMenu) private var showPlayNowInBackendContextMenu
+    @Default(.videoLoadingRetryCount) private var videoLoadingRetryCount
 
     @State private var filesToShare = [MPVClient.logFile]
     @State private var presentingShareSheet = false
@@ -64,6 +65,7 @@ struct AdvancedSettings: View {
     @ViewBuilder var advancedSettings: some View {
         Section(header: SettingsHeader(text: "Advanced")) {
             showPlayNowInBackendButtonsToggle
+            videoLoadingRetryCountField
         }
 
         Section(header: SettingsHeader(text: "MPV"), footer: mpvFooter) {
@@ -279,6 +281,19 @@ struct AdvancedSettings: View {
 
     var showPlayNowInBackendButtonsToggle: some View {
         Toggle("Show video context menu options to force selected backend", isOn: $showPlayNowInBackendContextMenu)
+    }
+
+    private var videoLoadingRetryCountField: some View {
+        HStack {
+            Text("Maximum retries for video loading")
+                .frame(minWidth: 200, alignment: .leading)
+                .multilineTextAlignment(.leading)
+            TextField("Limit", value: $videoLoadingRetryCount, formatter: NumberFormatter())
+                .multilineTextAlignment(.trailing)
+            #if !os(macOS)
+                .keyboardType(.numberPad)
+            #endif
+        }
     }
 
     var showMPVPlaybackStatsToggle: some View {


### PR DESCRIPTION
Since YouTube is conducting A/B testing again, many users may encounter the ‘This helps protect…’ message. I’ve added an auto-retry function to spare users from manually hitting retry, as videos typically load after 5-8 attempts.