### PR TITLE
improvements to MPVGLView

### DIFF
--- a/Open in Yattee/Open in Yattee.entitlements
+++ b/Open in Yattee/Open in Yattee.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.78Z5H3M6RJ.stream.yattee.app.urlbookmarks</string>
+		<string>group.ZYMM2HKXY2.yattee.app.url</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
- add Pixel Buffer Object to (PBO)
- add some debug logging
- add scissor testing
- add dirty region checking

This helps with drawing the video layer more efficient. Also, returning from background shouldn’t stall the video anymore, in some rare instances.