### PR TITLE
add drag gestures to video details

### DIFF
--- a/Shared/Player/PlayerBackendView.swift
+++ b/Shared/Player/PlayerBackendView.swift
@@ -43,7 +43,7 @@ struct PlayerBackendView: View {
                 Color.clear
                     .onAppear { player.playerSize = proxy.size }
                     .onChange(of: proxy.size) { _ in player.playerSize = proxy.size }
-                    .onChange(of: player.controls.presentingOverlays) { _ in player.playerSize = proxy.size }
+                    .onChange(of: player.currentItem?.id) { _ in player.playerSize = proxy.size }
             })
 
             #if !os(tvOS)

--- a/Shared/Player/Video Details/VideoDetails.swift
+++ b/Shared/Player/Video Details/VideoDetails.swift
@@ -223,7 +223,7 @@ struct VideoDetails: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())
             .padding(.horizontal, 16)
-            // swiftlint:disable trailing_closure
+
             // TODO: when setting tvOS minimum to 16, the platform modifier can be removed
             #if !os(tvOS)
                 .simultaneousGesture( // Simultaneous gesture to prioritize button tap
@@ -234,7 +234,7 @@ struct VideoDetails: View {
                     }
                 )
             #endif
-            // swiftlint:enable trailing_closure
+
             if VideoActions().isAnyActionVisible() {
                 VideoActions(video: player.videoForDisplay)
                     .padding(.vertical, 5)

--- a/Shared/Player/VideoPlayerView.swift
+++ b/Shared/Player/VideoPlayerView.swift
@@ -24,13 +24,12 @@ struct VideoPlayerView: View {
         #if os(macOS)
             335
         #else
-            200
+            140
         #endif
     }
 
     @State private var playerSize: CGSize = .zero { didSet { updateSidebarQueue() } }
     @State private var hoveringPlayer = false
-    @State private var fullScreenDetails = false
     @State private var sidebarQueue = defaultSidebarQueueValue
 
     @Environment(\.colorScheme) private var colorScheme
@@ -51,12 +50,14 @@ struct VideoPlayerView: View {
         @State var isHorizontalDrag = false
         @State var isVerticalDrag = false
         @State var viewDragOffset = Self.hiddenOffset
+        @State var detailViewDragOffset: Double = 0
         // swiftlint:enable private_swiftui_state
 
     #endif
 
     // swiftlint:disable private_swiftui_state
     @State var disableToggleGesture = false
+    @State var fullScreenDetails = false
     // swiftlint:enable private_swiftui_state
 
     @ObservedObject var player = PlayerModel.shared // swiftlint:disable:this swiftui_state_private
@@ -307,6 +308,8 @@ struct VideoPlayerView: View {
                             #endif
                             .id(player.currentVideo?.cacheKey)
                             .transition(.opacity)
+                            .offset(y: detailViewDragOffset)
+                            .gesture(detailsDragGesture)
                         } else {
                             VStack {}
                         }


### PR DESCRIPTION
Video details can now be toggled to/from fullscreen either by double tapping or swiping up/down in the header.

https://github.com/user-attachments/assets/eb90191e-ae3d-4384-aa07-48b5df9fbfcd