### PR TITLE
Stop making videos with unknown length shorts.

### DIFF
--- a/Model/Applications/InvidiousAPI.swift
+++ b/Model/Applications/InvidiousAPI.swift
@@ -498,7 +498,7 @@ final class InvidiousAPI: Service, ObservableObject, VideosAPI {
             indexID: indexID,
             live: json["liveNow"].boolValue,
             upcoming: json["isUpcoming"].boolValue,
-            short: length <= Video.shortLength,
+            short: length <= Video.shortLength && length != 0.0,
             publishedAt: publishedAt,
             likes: json["likeCount"].int,
             dislikes: json["dislikeCount"].int,


### PR DESCRIPTION
a workaround for an issue found at #848.

when videos have 0-length we can't assume it's a short because some invidious instances are using that as a default.