### PR TITLE
Add support for invidious companion

### DIFF
--- a/Model/Accounts/Instance.swift
+++ b/Model/Accounts/Instance.swift
@@ -10,14 +10,16 @@ struct Instance: Defaults.Serializable, Hashable, Identifiable {
     let apiURLString: String
     var frontendURL: String?
     var proxiesVideos: Bool
+    var invidiousCompanion: Bool
 
-    init(app: VideosApp, id: String? = nil, name: String? = nil, apiURLString: String, frontendURL: String? = nil, proxiesVideos: Bool = false) {
+    init(app: VideosApp, id: String? = nil, name: String? = nil, apiURLString: String, frontendURL: String? = nil, proxiesVideos: Bool = false, invidiousCompanion: Bool = false) {
         self.app = app
         self.id = id ?? UUID().uuidString
         self.name = name ?? app.rawValue
         self.apiURLString = apiURLString
         self.frontendURL = frontendURL
         self.proxiesVideos = proxiesVideos
+        self.invidiousCompanion = invidiousCompanion
     }
 
     var apiURL: URL! {

--- a/Model/Accounts/InstancesBridge.swift
+++ b/Model/Accounts/InstancesBridge.swift
@@ -16,7 +16,8 @@ struct InstancesBridge: Defaults.Bridge {
             "name": value.name,
             "apiURL": value.apiURLString,
             "frontendURL": value.frontendURL ?? "",
-            "proxiesVideos": value.proxiesVideos ? "true" : "false"
+            "proxiesVideos": value.proxiesVideos ? "true" : "false",
+            "invidiousCompanion": value.invidiousCompanion ? "true" : "false"
         ]
     }
 
@@ -33,7 +34,8 @@ struct InstancesBridge: Defaults.Bridge {
         let name = object["name"] ?? ""
         let frontendURL: String? = object["frontendURL"]!.isEmpty ? nil : object["frontendURL"]
         let proxiesVideos = object["proxiesVideos"] == "true"
+        let invidiousCompanion = object["invidiousCompanion"] == "true"
 
-        return Instance(app: app, id: id, name: name, apiURLString: apiURL, frontendURL: frontendURL, proxiesVideos: proxiesVideos)
+        return Instance(app: app, id: id, name: name, apiURLString: apiURL, frontendURL: frontendURL, proxiesVideos: proxiesVideos, invidiousCompanion: invidiousCompanion)
     }
 }

--- a/Model/Accounts/InstancesModel.swift
+++ b/Model/Accounts/InstancesModel.swift
@@ -79,6 +79,17 @@ final class InstancesModel: ObservableObject {
         Defaults[.instances][index] = instance
     }
 
+    func setInvidiousCompanion(_ instance: Instance, _ invidiousCompanion: Bool) {
+        guard let index = Defaults[.instances].firstIndex(where: { $0.id == instance.id }) else {
+            return
+        }
+
+        var instance = Defaults[.instances][index]
+        instance.invidiousCompanion = invidiousCompanion
+
+        Defaults[.instances][index] = instance
+    }
+
     func remove(_ instance: Instance) {
         let accounts = accounts(instance.id)
         if let index = Defaults[.instances].firstIndex(where: { $0.id == instance.id }) {

--- a/Shared/Settings/InstanceSettings.swift
+++ b/Shared/Settings/InstanceSettings.swift
@@ -8,6 +8,7 @@ struct InstanceSettings: View {
 
     @State private var frontendURL = ""
     @State private var proxiesVideos = false
+    @State private var invidiousCompanion = false
 
     var body: some View {
         List {
@@ -87,6 +88,16 @@ struct InstanceSettings: View {
                         InstancesModel.shared.setProxiesVideos(instance, newValue)
                     }
             }
+
+            if instance.app == .invidious {
+                invidiousCompanionToggle
+                    .onAppear {
+                        invidiousCompanion = instance.invidiousCompanion
+                    }
+                    .onChange(of: invidiousCompanion) { newValue in
+                        InstancesModel.shared.setInvidiousCompanion(instance, newValue)
+                    }
+            }
         }
         #if os(tvOS)
         .frame(maxWidth: 1000)
@@ -99,6 +110,10 @@ struct InstanceSettings: View {
 
     private var proxiesVideosToggle: some View {
         Toggle("Proxy videos", isOn: $proxiesVideos)
+    }
+    
+    private var invidiousCompanionToggle: some View {
+        Toggle("Invidious companion", isOn: $invidiousCompanion)
     }
 
     private func removeAccount(_ account: Account) {

--- a/macOS/InstancesSettings.swift
+++ b/macOS/InstancesSettings.swift
@@ -11,6 +11,7 @@ struct InstancesSettings: View {
 
     @State private var frontendURL = ""
     @State private var proxiesVideos = false
+    @State private var invidiousCompanion = false
 
     @Environment(\.colorScheme) private var colorScheme
     @ObservedObject private var accounts = AccountsModel.shared
@@ -105,6 +106,16 @@ struct InstancesSettings: View {
                     }
             }
 
+            if selectedInstance != nil, selectedInstance.app == .invidious {
+                invidiousCompanionToggle
+                    .onAppear {
+                        invidiousCompanion = selectedInstance.invidiousCompanion
+                    }
+                    .onChange(of: invidiousCompanion) { newValue in
+                        InstancesModel.shared.setInvidiousCompanion(selectedInstance, newValue)
+                    }
+            }
+
             if selectedInstance != nil, !selectedInstance.app.supportsAccounts {
                 Spacer()
                 Text("Accounts are not supported for the application of this instance")
@@ -190,6 +201,10 @@ struct InstancesSettings: View {
 
     private var proxiesVideosToggle: some View {
         Toggle("Proxy videos", isOn: $proxiesVideos)
+    }
+
+    private var invidiousCompanionToggle: some View {
+        Toggle("Invidious companion", isOn: $invidiousCompanion)
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/yattee/yattee/issues/853

Invidious has recently [added support](https://github.com/iv-org/invidious/pull/4985) for a so called companion, which handles retrieval of YouTube streams.
When using the companion, Invidious API doesn't yet return a working stream URLs - see https://github.com/iv-org/invidious-companion/issues/22.
Invidious frontend uses the [latest_version](https://github.com/iv-org/invidious-companion/blob/master/src/routes/invidious_routes/latestVersion.ts) endpoint instead, which for a given video `ID` and `itag` returns a working stream URL.

This PR adds an "Invidious companion" toggle to settings and if it is turned on, replaces stream URLs with the `latest_version` endpoint.

It fixes the issue mentioned, I tested it.