### PR TITLE
feat: MPV audio track switching and fix default audio language

### DIFF
--- a/Model/Player/PlayerModel.swift
+++ b/Model/Player/PlayerModel.swift
@@ -210,6 +210,14 @@ final class PlayerModel: ObservableObject {
         var keyPressMonitor: Any?
     #endif
 
+    @Published var selectedAudioTrackIndex = 0 {
+        didSet {
+            if oldValue != selectedAudioTrackIndex {
+                handleAudioTrackChange()
+            }
+        }
+    }
+
     init() {
         #if os(iOS)
             isOrientationLocked = Defaults[.isOrientationLocked]
@@ -1467,4 +1475,12 @@ final class PlayerModel: ObservableObject {
             }
         }
     #endif
+
+    private func handleAudioTrackChange() {
+        (backend as? MPVBackend)?.switchAudioTrack(to: selectedAudioTrackIndex)
+    }
+
+    var availableAudioTracks: [Stream.AudioTrack] {
+        (backend as? MPVBackend)?.availableAudioTracks ?? []
+    }
 }

--- a/Model/Stream.swift
+++ b/Model/Stream.swift
@@ -191,6 +191,25 @@ class Stream: Equatable, Hashable, Identifiable {
             return .unknown
         }
     }
+    
+    struct AudioTrack: Hashable, Identifiable {
+        let id = UUID().uuidString
+        let url: URL
+        let content: String?
+        let language: String?
+        
+        var displayLanguage: String {
+            LanguageCodes(rawValue: language ?? "")?.description.capitalized ?? language ?? "Unknown"
+        }
+        
+        var description: String {
+            "\(displayLanguage) (\(content ?? "Unknown"))"
+        }
+        
+        var isDubbed: Bool {
+            content?.lowercased().starts(with: "dubbed") ?? false
+        }
+    }
 
     let id = UUID()
 
@@ -208,6 +227,8 @@ class Stream: Equatable, Hashable, Identifiable {
     var videoFormat: String?
     var bitrate: Int?
     var requestRange: String?
+    var audioTracks: [AudioTrack] = []
+    var selectedAudioTrackIndex = 0
 
     init(
         instance: Instance? = nil,
@@ -220,7 +241,8 @@ class Stream: Equatable, Hashable, Identifiable {
         encoding: String? = nil,
         videoFormat: String? = nil,
         bitrate: Int? = nil,
-        requestRange: String? = nil
+        requestRange: String? = nil,
+        audioTracks: [AudioTrack] = []
     ) {
         self.instance = instance
         self.audioAsset = audioAsset
@@ -233,6 +255,7 @@ class Stream: Equatable, Hashable, Identifiable {
         format = .from(videoFormat ?? "")
         self.bitrate = bitrate
         self.requestRange = requestRange
+        self.audioTracks = audioTracks
     }
 
     var isLocal: Bool {

--- a/Shared/LanguageCodes.swift
+++ b/Shared/LanguageCodes.swift
@@ -11,6 +11,7 @@ enum LanguageCodes: String, CaseIterable {
     case Greek = "el"
     case English = "en"
     case English_GB = "en-GB"
+    case English_US = "en-US"
     case Spanish = "es"
     case Persian = "fa"
     case Finnish = "fi"
@@ -76,6 +77,8 @@ enum LanguageCodes: String, CaseIterable {
             return "English"
         case .English_GB:
             return "English (United Kingdom)"
+        case .English_US:
+            return "English (United States)"
         case .Spanish:
             return "Spanish"
         case .Persian:


### PR DESCRIPTION
Fixes https://github.com/yattee/yattee/issues/852

## Changes
1. Fix audio language defaulting to dubbed versions for foreign videos (https://github.com/yattee/yattee/issues/852)
    - This is done by parsing the `xtags` present in the audio track URL to detect whether it is a dubbed audio or not (e.g. `acont=dubbed-auto:lang=en-US` vs `acont=original:lang=it`). The original audio is then returned as first track to default to
2. Allow audio track switching while playing a video with MPV (this is something already implemented in Invidious web frontend, and I felt it was missing in Yattee)
    - This is done by saving all available audio tracks in the `Stream` class
    - A new picker menu is added in both playback settings and overlay controls to change audio track
      - Audio track switching is done simply by reloading the stream with a different audio asset. I've tested other solutions (such as using [MPV's `audio-add` subcommand](https://mpv.io/manual/master/#command-interface-audio-add[%3Clang%3E]]])) but ultimately that lead to delays and audio going out of sync)

Tested on iOS, macOS and tvOS

> [!IMPORTANT]  
> This will not work with Invidious Companion toggle switched on (added in https://github.com/yattee/yattee/pull/863) - meaning the language will stay the same when changing audio track 
The reason is that both the dubbed audio and the original audio have the **same** `itag` (example: v=mgnBUvXYrts, `itag` 140). So when using Invidious Companion's [latest_version](https://github.com/iv-org/invidious-companion/blob/master/src/routes/invidious_routes/latestVersion.ts) endpoint, the audio URL will be `/latest_version?id=mgnBUvXYrts&itag=140` for both. Feel free to suggest a solution, as I couldn't find any

## Screenshots

### iOS
<img width="300" alt="image" src="https://github.com/user-attachments/assets/994b54e4-0ed0-4d43-aafa-7c3fac04643d" />

### macOS
<img width="1212" alt="image" src="https://github.com/user-attachments/assets/f82a0647-8c31-4a11-90cb-6a17b9fcb276" />

### tvOS
<img width="1348" alt="image" src="https://github.com/user-attachments/assets/183305a1-14a4-4ce1-86ad-3de046eb970a" />
