### PR TITLE
Support Invidious servers which have unspecified domains (... at least for thumbnail URLs 🙂)

### DIFF
--- a/Model/Applications/InvidiousAPI.swift
+++ b/Model/Applications/InvidiousAPI.swift
@@ -612,6 +612,9 @@ final class InvidiousAPI: Service, ObservableObject, VideosAPI {
             // Some instances are not configured properly and return thumbnail links
             // with an incorrect scheme or a missing port.
             components.scheme = accountUrlComponents.scheme
+            if (components.host ?? "") == "" {
+                components.host = accountUrlComponents.host
+            }
             components.port = accountUrlComponents.port
 
             // If basic HTTP authentication is used,


### PR DESCRIPTION
First off: Thanks for making this app! It's super impressive for a first Swift app - really nice work. And the codebase is pretty easy to dive right into, even for a non-Swift developer like myself.

Also, I know you're in the middle of a rewrite, so please feel free to ignore this PR until the rewrite's done! Onto the PR:

I was experiencing #869 (thumbnails not loading), but not for the reason I believe specified in that issue.

For me, it was because I had deliberately configured the "domain" of my personal invidious instance to be unset. This is a valid configuration of Invidious that should be supported by any client applications, in my view (though I am but a humble user of Invidious, so I am not saying this from any position of authority)

I'll go into the reason later, but given this configuration, the URLs for thumbnails generated by the Invidious API are paths only. This PR supports this case by defaulting thumbnail URL's hosts to the configured server URL's host, when they are nil or `""`

## Use Case

This is because I want to support two use-cases for my invidious server: 

1. at-home usage, from my iPad and possibly in future from my Apple TV (in which case, I will need an app such as Yattee)
2. away-from-home usage, from my iPad.

This is a private instance, so for anyone who isn't inside my home I want to restrict access behind my single-sign-on authentication proxy.

### The Story

I'll walk you through my story in full, but the tl;dr is I need to use a different domain inside my network (some 192.168.. address) vs externally - where even the invidious API must live behind the authentication proxy.

Invidious works great through Safari on my iPad, so at first I threw it behind my usual authentication proxy and called it good.
When I came to trying out Yattee, I knew I'd need to bypass the authentication proxy for access to the `/api` endpoints, so I set that up.
Then I found that I couldn't login. Checked the logs of my proxy, discovered I needed to bypass `/login` too... OK, weird that the API endpoints don't have a login mechanism (or.. that there's no API tokens stuff), but, fine. Added that to the bypass.

Tried again, and though I could log in now, the thumbnails and proxied videos were not loading. Looking at my authentication proxy, I saw that yattee was *also* loading video thumbnails from outside the `/api`.

So this is where I googled a bit and re-evaluated the whole situation:

Not only does Invidious not have `/api`-mounted endpoints for loading thumbnails, it also has no way to require authentication to access any of its endpoints (except the per-user stuff).

I'm not trying to run an Invidious instance for everyone in the world, so I knew I needed, at least externally, to un-bypass the authentication proxy.

So I did that: removed the domain from invidious so that (I was hoping) it would generate URLs with whatever Host header it received from the client), and opened up a port on my server to allow access to Invidious from my LAN, bypassing all proxies.

Now Yattee could login, and could get videos, but couldn't get thumbnails. The thumbnail URLs in the API are actually coming out as just paths: `/vi/<id>/<something>.jpg`. So I assume there's some network request attempt failing (and getting handled instead of crashing?) inside Yattee.

And that is what this commit fixes!