### PR TITLE
Add tvOS deep link support for yattee:// URL scheme

### DIFF
--- a/Shared/YatteeApp.swift
+++ b/Shared/YatteeApp.swift
@@ -37,6 +37,8 @@ struct YatteeApp: App {
     #elseif os(iOS)
         @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
         @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    #elseif os(tvOS)
+        @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     #endif
 
     @State private var configured = false
@@ -86,12 +88,10 @@ struct YatteeApp: App {
             #if os(iOS)
             .handlesExternalEvents(preferring: Set(["*"]), allowing: Set(["*"]))
             #endif
-            #if !os(tvOS)
             .onOpenURL { url in
                 URLBookmarkModel.shared.saveBookmark(url)
                 OpenURLHandler(navigationStyle: navigationStyle).handle(url)
             }
-            #endif
         }
         #if os(iOS)
         .handlesExternalEvents(matching: Set(["*"]))

--- a/Yattee.xcodeproj/project.pbxproj
+++ b/Yattee.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		01DEEPLNK553TVOS0001 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DEEPLNK553TVOS0002 /* AppDelegate.swift */; };
 		1B81344D4D2A0B0363850A9E /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D886FD1371688A42060DF82 /* FeatureFlags.swift */; };
 		2446210B2B03C320154634A5 /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D886FD1371688A42060DF82 /* FeatureFlags.swift */; };
 		3528A0FEB2B02A52B715041C /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D886FD1371688A42060DF82 /* FeatureFlags.swift */; };
@@ -1165,6 +1166,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		01DEEPLNK553TVOS0002 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		3700155A271B0D4D0049C794 /* PipedAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipedAPI.swift; sourceTree = "<group>"; };
 		3700155E271B12DD0049C794 /* SiestaConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiestaConfiguration.swift; sourceTree = "<group>"; };
 		37001562271B1F250049C794 /* AccountsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountsModel.swift; sourceTree = "<group>"; };
@@ -2379,6 +2381,7 @@
 		37D4B159267164AE00C925CA /* tvOS */ = {
 			isa = PBXGroup;
 			children = (
+				01DEEPLNK553TVOS0002 /* AppDelegate.swift */,
 				37D6025C28C17719009E8D98 /* ControlsOverlayButton.swift */,
 				3730D89F2712E2B70020ED53 /* NowPlayingView.swift */,
 				37BAB54B269B39FD00E75ED1 /* TVNavigationView.swift */,
@@ -3801,6 +3804,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				01DEEPLNK553TVOS0001 /* AppDelegate.swift in Sources */,
 				37579D5F27864F5F00FD0B98 /* Help.swift in Sources */,
 				370015AB28BBAE7F000149FD /* ProgressBar.swift in Sources */,
 				375EC95F289EEEE000751258 /* QualityProfile.swift in Sources */,

--- a/tvOS/AppDelegate.swift
+++ b/tvOS/AppDelegate.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Logging
+import UIKit
+
+final class AppDelegate: UIResponder, UIApplicationDelegate {
+    private var logger = Logger(label: "stream.yattee.app.tvos.delegate")
+
+    func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        return true
+    }
+
+    func application(_: UIApplication, open url: URL, options _: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        if url.scheme == "yattee" {
+            logger.info("handling deep link: \(url.absoluteString)")
+            OpenURLHandler(navigationStyle: .tab).handle(url)
+            return true
+        }
+        return false
+    }
+}

--- a/tvOS/Info.plist
+++ b/tvOS/Info.plist
@@ -2,6 +2,19 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>net.yattee.app.watch</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>yattee</string>
+			</array>
+		</dict>
+	</array>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>


### PR DESCRIPTION
Enable deep link handling on tvOS to allow automations to open videos via yattee://watch?v=<video_id> URLs, matching existing iOS/macOS behavior.

Changes:
- Add CFBundleURLTypes to tvOS Info.plist for yattee:// scheme
- Remove tvOS exclusion from .onOpenURL handler in YatteeApp.swift
- Add UIApplicationDelegateAdaptor for tvOS
- Create tvOS AppDelegate with URL handling fallback

Fixes #553