### PR TITLE
Fix www.duckduckgo.com misrouting to yt-dlp external video extraction

### DIFF
--- a/Yattee/Services/Navigation/URLRouter.swift
+++ b/Yattee/Services/Navigation/URLRouter.swift
@@ -84,7 +84,7 @@ struct URLRouter: Sendable {
         let excludedHosts = [
             "google.com", "www.google.com",
             "bing.com", "www.bing.com",
-            "duckduckgo.com",
+            "duckduckgo.com", "www.duckduckgo.com",
             "apple.com", "www.apple.com",
             "github.com", "www.github.com"
         ]

--- a/YatteeTests/NavigationTests.swift
+++ b/YatteeTests/NavigationTests.swift
@@ -273,6 +273,26 @@ struct URLRouterTests {
         }
     }
 
+    // MARK: - External Host Exclusion Tests
+
+    @Test("www.duckduckgo.com is excluded from external video routing")
+    func wwwDuckDuckGoExcluded() {
+        let url = URL(string: "https://www.duckduckgo.com/?q=cat+videos")!
+        let destination = router.route(url)
+        if case .externalVideo = destination {
+            Issue.record("www.duckduckgo.com must not route to externalVideo; yt-dlp extraction should not run for a search engine")
+        }
+    }
+
+    @Test("duckduckgo.com bare host remains excluded from external video")
+    func duckDuckGoBareExcluded() {
+        let url = URL(string: "https://duckduckgo.com/?q=test")!
+        let destination = router.route(url)
+        if case .externalVideo = destination {
+            Issue.record("duckduckgo.com must not route to externalVideo; yt-dlp extraction should not run for a search engine")
+        }
+    }
+
     // MARK: - YouTube Channel URL Tests
 
     @Test("Parse YouTube channel URL")


### PR DESCRIPTION
`URLRouter.route(_:)`'s `.externalVideo` fallback skipped DuckDuckGo only in its bare form — `excludedHosts` lacked the `www.` entry that every other excluded host has (google, bing, apple, github all list both bare and `www.`). A `https://www.duckduckgo.com/?q=…` search hit the external-video path and triggered yt-dlp extraction on a search-engine page.

- `URLRouter.swift`: add `"www.duckduckgo.com"` to `excludedHosts`, matching the `www.`-plus-bare shape of every sibling entry.
- `NavigationTests.swift`: two Swift Testing cases — `www.duckduckgo.com` and bare `duckduckgo.com` both must not route to `.externalVideo`.

Built and verified on macOS, `xcodebuild test -scheme Yattee -destination 'platform=macOS'` (URLRouterTests green with `CODE_SIGNING_ALLOWED=NO` on this host, which has no Mac Development certificate — the routing logic is fully exercised regardless of signing).