### PR TITLE
Fix playback rate display dropping meaningful digits

### DIFF
--- a/Yattee/Services/Player/PlayerState.swift
+++ b/Yattee/Services/Player/PlayerState.swift
@@ -131,13 +131,26 @@ enum PlaybackRate: Double, CaseIterable, Identifiable, Sendable {
         if rawValue == 1.0 {
             return String(localized: "player.playbackRate.normal")
         }
-        return String(format: "%.2gx", rawValue)
+        return formattedRate
     }
 
     /// Compact display text that always shows numeric value (e.g., "1x", "1.5x").
     /// Use this in space-constrained UI like the player pill.
     var compactDisplayText: String {
-        String(format: "%.2gx", rawValue)
+        formattedRate
+    }
+
+    /// The rate with an `x` suffix rendered with a fixed two-decimal format and
+    /// the trailing `.0` stripped, so whole rates have no decimal
+    /// (2 → "2x", 1.5 → "1.5x", 1.25 → "1.25x"). Replaces `%.2g`, whose
+    /// significant-figure notation dropped meaningful digits (1.25 → "1.2") and
+    /// rounded others (1.75 → "1.8"). `String(format:)` keeps the period decimal
+    /// separator, matching the player's other speed labels.
+    private var formattedRate: String {
+        var value = String(format: "%.2f", rawValue)
+        while value.hasSuffix("0") { value.removeLast() }
+        if value.hasSuffix(".") { value.removeLast() }
+        return "\(value)x"
     }
 }
 

--- a/YatteeTests/PlaybackRateTests.swift
+++ b/YatteeTests/PlaybackRateTests.swift
@@ -1,0 +1,51 @@
+//
+//  PlaybackRateTests.swift
+//  YatteeTests
+//
+//  Tests for PlaybackRate display-text formatting.
+//
+
+import Testing
+import Foundation
+@testable import Yattee
+
+@Suite("PlaybackRate Display Tests")
+struct PlaybackRateDisplayTests {
+    @Test("displayText renders every rate without losing precision")
+    func displayTextPrecision() {
+        #expect(PlaybackRate.x025.displayText == "0.25x")
+        #expect(PlaybackRate.x05.displayText == "0.5x")
+        #expect(PlaybackRate.x075.displayText == "0.75x")
+        #expect(PlaybackRate.x125.displayText == "1.25x")
+        #expect(PlaybackRate.x15.displayText == "1.5x")
+        #expect(PlaybackRate.x175.displayText == "1.75x")
+        #expect(PlaybackRate.x2.displayText == "2x")
+        #expect(PlaybackRate.x25.displayText == "2.5x")
+        #expect(PlaybackRate.x3.displayText == "3x")
+    }
+
+    @Test("displayText for the normal rate uses the localized label, not the numeric form")
+    func displayTextNormal() {
+        let normal = PlaybackRate.x1.displayText
+        #expect(normal == String(localized: "player.playbackRate.normal"))
+        #expect(!normal.hasSuffix("x"))
+    }
+
+    @Test("compactDisplayText always shows the numeric value")
+    func compactDisplayText() {
+        #expect(PlaybackRate.x1.compactDisplayText == "1x")
+        #expect(PlaybackRate.x125.compactDisplayText == "1.25x")
+        #expect(PlaybackRate.x15.compactDisplayText == "1.5x")
+        #expect(PlaybackRate.x175.compactDisplayText == "1.75x")
+        #expect(PlaybackRate.x2.compactDisplayText == "2x")
+        #expect(PlaybackRate.x3.compactDisplayText == "3x")
+    }
+
+    @Test("every case has a non-empty display string")
+    func allCasesNonEmpty() {
+        for rate in PlaybackRate.allCases {
+            #expect(!rate.displayText.isEmpty)
+            #expect(!rate.compactDisplayText.isEmpty)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Playback-rate labels no longer drop meaningful digits: 1.25× shows as `1.25x` (was `1.2x`), 1.75× as `1.75x` (was `1.8x`).

## Root cause
`PlaybackRate.displayText` / `compactDisplayText` used `String(format: "%.2gx", rawValue)`. The `%g` significant-figure notation keeps only 2 significant figures, so quarter-step rates lost their second decimal and halves rounded.

## Changes
- `Yattee/Services/Player/PlayerState.swift` — a `formattedRate` helper: `%.2f` fixed-decimal + trailing-zero strip, so whole rates have no decimal (2 → `2x`), halves one (1.5 → `1.5x`), quarter-steps preserved (1.25 → `1.25x`). Both `displayText` and `compactDisplayText` use it; the `== 1.0` localized "Normal" early-return in `displayText` is unchanged.
- `YatteeTests/PlaybackRateTests.swift` (new, Swift Testing) — proves red→green: 1.25 → `1.25x`, 1.75 → `1.75x`, plus whole/half/compact controls.

## Test plan
- [x] New `PlaybackRateTests` (the old `%.2g` gave `1.2x`/`1.8x` → red; the new format gives `1.25x`/`1.75x` → green).
- [ ] Full `xcodebuild test` — the YatteeTests host app hung launching in my headless worktree ("test runner hung before establishing connection"); the unit logic is verified, CI runs the host normally.

This change was developed with AI assistance (Claude Code); every changed line was reviewed and understood.