### PR TITLE
Fix deep link timestamp parsing accepting infinity as seek position

### DIFF
--- a/Yattee/Services/Navigation/URLRouter.swift
+++ b/Yattee/Services/Navigation/URLRouter.swift
@@ -145,9 +145,11 @@ struct URLRouter: Sendable {
         let trimmed = raw.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return nil }
 
-        // Plain numeric value (e.g. "90", "90.5")
+        // Plain numeric value (e.g. "90", "90.5"). Reject non-finite values
+        // ("inf"/"infinity"/"nan") that `TimeInterval(_:)` accepts — a `?t=inf`
+        // link would otherwise seek the player to `Double.infinity`.
         if let value = TimeInterval(trimmed) {
-            return value >= 0 ? value : nil
+            return (value.isFinite && value >= 0) ? value : nil
         }
 
         // Compound form like "1h2m3s", "2m30s", "90s"

--- a/YatteeTests/NavigationTests.swift
+++ b/YatteeTests/NavigationTests.swift
@@ -123,6 +123,20 @@ struct URLRouterTests {
         #expect(URLRouter.parseTimestampValue("90.5") == 90.5)
     }
 
+    @Test("Reject non-finite and negative plain timestamp values")
+    func rejectInvalidPlainTimestampValues() {
+        // Plain numeric values that are accepted by TimeInterval(_:) but are not
+        // valid seek targets must return nil rather than poisoning the player.
+        #expect(URLRouter.parseTimestampValue("inf") == nil)
+        #expect(URLRouter.parseTimestampValue("infinity") == nil)
+        #expect(URLRouter.parseTimestampValue("nan") == nil)
+        #expect(URLRouter.parseTimestampValue("-5") == nil)
+        // Valid plain seconds still parse.
+        #expect(URLRouter.parseTimestampValue("0") == 0)
+        #expect(URLRouter.parseTimestampValue("90") == 90)
+        #expect(URLRouter.parseTimestampValue("90.5") == 90.5)
+    }
+
     // MARK: - Share Extension Wrapper Tests
 
     @Test("Unwrap yattee://open wrapper to inner URL with timestamp")


### PR DESCRIPTION
## Problem

`URLRouter.parseTimestampValue(_:)` parses the `t` / `time` / `start` query parameter from deep links and share URLs (YouTube watch URLs, `youtu.be` short links, `yattee://open?url=…` wrappers). The plain-numeric branch used `TimeInterval(_:)`:

```swift
if let value = TimeInterval(trimmed) {
    return value >= 0 ? value : nil
}
```

`TimeInterval(_:)` accepts more than decimal numbers — it also parses the special floating-point tokens `inf` / `infinity` / `nan`. Because `Double.infinity >= 0` is `true`, a link carrying `?t=inf` parsed to `Double.infinity`, which was then forwarded to the player as a seek target. Seeking to infinity is undefined and breaks playback startup for that link. (`nan` already fell through the `>= 0` check, but `inf` did not.)

## Root cause

No finite-value guard: `TimeInterval(_:)` succeeding is not the same as the string being a real, usable number of seconds.

## Changes

- `Yattee/Services/Navigation/URLRouter.swift`: require `value.isFinite` in addition to the existing `value >= 0` check in the plain-numeric branch of `parseTimestampValue`. Compound forms (`1h2m3s`, `2m30s`) are unaffected — they only ever accumulate finite per-unit products.
- `YatteeTests/NavigationTests.swift`: add `URLRouterTests.rejectInvalidPlainTimestampValues` covering `inf` / `infinity` / `nan` / negative rejection, plus a few valid plain seconds that must still parse.

## Verification

- Built and verified the Swift Testing target compiles on macOS 26 with Xcode 26.4.1: `xcodebuild build-for-testing -scheme Yattee -destination 'platform=macOS'` succeeded.
- The full `URLRouterTests` suite (including the new case) is headless-runnable via `xcodebuild test -scheme Yattee -destination 'platform=macOS' -only-testing:YatteeTests/URLRouterTests`. In my local environment the GUI-app test host crashed before bootstrapping (a known headless-host limitation unrelated to this change), so the maintainer's local run is the gate per the repo's contributor guide (there is no PR CI).

- [x] macOS
- [ ] iOS
- [ ] tvOS