### PR TITLE
Fix description timestamp links seeking to wrong position for out-of-range values

### DIFF
--- a/Yattee/Utilities/DescriptionText.swift
+++ b/Yattee/Utilities/DescriptionText.swift
@@ -56,12 +56,13 @@ enum DescriptionText {
                 }
 
                 let timestampString = String(text[range])
-                let seconds = parseTimestamp(timestampString)
-
-                if let url = URL(string: "yattee-seek://\(seconds)") {
-                    attributedString[attributedRange].link = url
-                    attributedString[attributedRange].foregroundColor = linkColor
+                guard let seconds = parseTimestamp(timestampString),
+                      let url = URL(string: "yattee-seek://\(seconds)") else {
+                    continue
                 }
+
+                attributedString[attributedRange].link = url
+                attributedString[attributedRange].foregroundColor = linkColor
             }
         }
 
@@ -69,15 +70,24 @@ enum DescriptionText {
     }
 
     /// Parses a timestamp string (MM:SS or H:MM:SS) into total seconds.
-    static func parseTimestamp(_ timestamp: String) -> Int {
+    /// Returns nil when a component is out of its valid range (e.g. `1:99`,
+    /// `0:60`, `1:99:30`); those strings are matched by the link regex above
+    /// but are not valid clock positions, so they must not become seek links.
+    /// This mirrors the range validation in `ChapterParser`.
+    static func parseTimestamp(_ timestamp: String) -> Int? {
         let components = timestamp.split(separator: ":").compactMap { Int($0) }
         switch components.count {
         case 2: // MM:SS
-            return components[0] * 60 + components[1]
+            let seconds = components[1]
+            guard seconds < 60 else { return nil }
+            return components[0] * 60 + seconds
         case 3: // H:MM:SS
-            return components[0] * 3600 + components[1] * 60 + components[2]
+            let minutes = components[1]
+            let seconds = components[2]
+            guard minutes < 60, seconds < 60 else { return nil }
+            return components[0] * 3600 + minutes * 60 + seconds
         default:
-            return 0
+            return nil
         }
     }
 

--- a/YatteeTests/DescriptionTextTests.swift
+++ b/YatteeTests/DescriptionTextTests.swift
@@ -1,0 +1,67 @@
+//
+//  DescriptionTextTests.swift
+//  YatteeTests
+//
+//  Unit tests for description-text timestamp parsing.
+//
+
+import Testing
+import Foundation
+@testable import Yattee
+
+@Suite("DescriptionText Timestamp Parsing")
+struct DescriptionTextTimestampTests {
+
+    // MARK: - Valid Timestamps
+
+    @Test("Parses M:SS format")
+    func parseMSS() {
+        #expect(DescriptionText.parseTimestamp("0:00") == 0)
+        #expect(DescriptionText.parseTimestamp("5:30") == 330)
+    }
+
+    @Test("Parses MM:SS format")
+    func parseMMSS() {
+        #expect(DescriptionText.parseTimestamp("00:00") == 0)
+        #expect(DescriptionText.parseTimestamp("12:45") == 765)
+        #expect(DescriptionText.parseTimestamp("59:59") == 3599)
+    }
+
+    @Test("Parses H:MM:SS format")
+    func parseHMMSS() {
+        #expect(DescriptionText.parseTimestamp("1:23:45") == 5025)
+        #expect(DescriptionText.parseTimestamp("01:23:45") == 5025)
+    }
+
+    @Test("Parses long minutes in MM:SS form")
+    func parseLongMinutes() {
+        // A 99-minute position is valid for a long video (2-digit minutes).
+        #expect(DescriptionText.parseTimestamp("99:59") == 5999)
+    }
+
+    // MARK: - Out-of-Range Rejection (regression)
+
+    @Test("Rejects seconds >= 60 in MM:SS form")
+    func rejectsInvalidSeconds() {
+        // Previously returned components[0]*60 + components[1] = 60 and 159,
+        // seeking the player to the wrong position.
+        #expect(DescriptionText.parseTimestamp("0:60") == nil)
+        #expect(DescriptionText.parseTimestamp("1:99") == nil)
+        #expect(DescriptionText.parseTimestamp("5:75") == nil)
+    }
+
+    @Test("Rejects minutes or seconds >= 60 in H:MM:SS form")
+    func rejectsInvalidHoursMinutesSeconds() {
+        #expect(DescriptionText.parseTimestamp("1:99:30") == nil)
+        #expect(DescriptionText.parseTimestamp("1:30:60") == nil)
+        #expect(DescriptionText.parseTimestamp("2:60:00") == nil)
+    }
+
+    // MARK: - Boundary
+
+    @Test("Accepts the 59 boundary in every field")
+    func acceptsBoundary() {
+        #expect(DescriptionText.parseTimestamp("59:59") == 3599)
+        #expect(DescriptionText.parseTimestamp("1:59:59") == 7199)
+    }
+}


### PR DESCRIPTION
## Problem

Tappable timestamps inside a video description are produced by `DescriptionText.attributed(_:)`: a regex matches clock-like strings (`\d{1,2}:\d{2}(?::\d{2})?`), each match is converted to seconds by `DescriptionText.parseTimestamp(_:)`, and that many seconds becomes a `yattee-seek://` link.

`parseTimestamp` computed seconds from the colon-separated parts with **no range validation**:

```swift
case 2: // MM:SS
    return components[0] * 60 + components[1]
case 3: // H:MM:SS
    return components[0] * 3600 + components[1] * 60 + components[2]
```

The link regex matches strings that are not valid clock positions — `1:99`, `0:60`, `1:99:30`. For `1:99`, `parseTimestamp` returned `1*60 + 99 = 159`, so tapping that link seeked the player to 2:39 instead of being ignored. This also diverged from `ChapterParser`, which rejects seconds/minutes >= 60: the same string could be dropped as a chapter while still seeking as a description link.

## Root cause

No positional range check: a successful regex match was treated as a guaranteed-valid timestamp.

## Changes

- `Yattee/Utilities/DescriptionText.swift`: validate `seconds < 60` in the `MM:SS` branch and `minutes < 60, seconds < 60` in the `H:MM:SS` branch. `parseTimestamp` now returns `Int?`; the single call site in `attributed(_:)` skips building the seek link for `nil`, so out-of-range matches are left as plain text. Mirrors the validation already in `ChapterParser`.
- `YatteeTests/DescriptionTextTests.swift`: new Swift Testing suite covering valid (`5:30`, `12:45`, `1:23:45`, `99:59`), boundary (`59:59`, `1:59:59`) and out-of-range (`0:60`, `1:99`, `5:75`, `1:99:30`, `1:30:60`, `2:60:00`) cases.

## Verification

- Built and verified the Swift Testing target compiles on macOS 26 with Xcode 26.4.1: `xcodebuild build-for-testing -scheme Yattee -destination 'platform=macOS'` succeeded (new test file is picked up by the folder-synchronized test target).
- The `DescriptionTextTimestampTests` suite is headless-runnable via `xcodebuild test -scheme Yattee -destination 'platform=macOS' -only-testing:YatteeTests/DescriptionTextTimestampTests`. In my local environment the GUI-app test host crashed before bootstrapping (a known headless-host limitation unrelated to this change), so the maintainer's local run is the gate per the repo's contributor guide (there is no PR CI).

- [x] macOS
- [ ] iOS
- [ ] tvOS