### PR TITLE
Fix no streams reported from Piped

### DIFF
--- a/Yattee/Services/API/PipedAPI.swift
+++ b/Yattee/Services/API/PipedAPI.swift
@@ -672,12 +672,14 @@ private struct PipedVideoStream: Decodable, Sendable {
             resolution = nil
         }
 
+        let audioCodec: String? = (videoOnly ?? true) ? nil : "aac"
+
         return Stream(
             url: streamUrl,
             resolution: resolution,
             format: format ?? "unknown",
             videoCodec: codec,
-            audioCodec: nil,
+            audioCodec: audioCodec,
             bitrate: bitrate,
             fileSize: contentLength,
             isAudioOnly: false,


### PR DESCRIPTION
Piped currently is having an issue it would only return a muxed 360p stream, and it is rejected here because the audioCodec being set to nil.

Resolve https://github.com/yattee/yattee/issues/973