### PR TITLE
Preserve pending changes when refreshing iCloud sync

### DIFF
--- a/Yattee/Services/CloudKit/CloudKitSyncEngine.swift
+++ b/Yattee/Services/CloudKit/CloudKitSyncEngine.swift
@@ -1428,10 +1428,17 @@ final class CloudKitSyncEngine: @unchecked Sendable {
         // Clear local sync state so CKSyncEngine fetches everything fresh
         UserDefaults.standard.removeObject(forKey: syncStateKey)
 
+        // Keep queued local changes: Sync Now refreshes the fetch cursor, not
+        // the user's unsent edits.
+        let pendingChanges = Self.pendingChangesForRefresh(
+            engineChanges: syncEngine?.state.pendingRecordZoneChanges ?? [],
+            bufferedChanges: pendingChangesBuffer
+        )
+
         // Tear down existing engine
         debounceTimer?.invalidate()
         debounceTimer = nil
-        pendingChangesBuffer.removeAll()
+        pendingChangesBuffer = pendingChanges
         conflictResolvedRecords.removeAll()
         retryCount.removeAll()
         syncEngine = nil
@@ -1442,6 +1449,13 @@ final class CloudKitSyncEngine: @unchecked Sendable {
         await setupSyncEngine()
 
         LoggingService.shared.logCloudKit("Refresh sync completed")
+    }
+
+    static func pendingChangesForRefresh(
+        engineChanges: [CKSyncEngine.PendingRecordZoneChange],
+        bufferedChanges: [CKSyncEngine.PendingRecordZoneChange]
+    ) -> [CKSyncEngine.PendingRecordZoneChange] {
+        engineChanges + bufferedChanges
     }
 
     /// Clear all sync state and reset. For testing/debugging only.

--- a/YatteeTests/CloudKitSyncTests.swift
+++ b/YatteeTests/CloudKitSyncTests.swift
@@ -13,6 +13,29 @@ import Testing
 @Suite("CloudKit Sync")
 struct CloudKitSyncTests {
 
+    @Test("Sync refresh keeps pending record-zone changes")
+    @MainActor
+    func refreshPreservesPendingChanges() {
+        let zone = CKRecordZone(zoneName: RecordType.zoneName)
+        let recordID = CKRecord.ID(recordName: "watch-video@global:youtube", zoneID: zone.zoneID)
+        let changes = CloudKitSyncEngine.pendingChangesForRefresh(
+            engineChanges: [.saveRecord(recordID)],
+            bufferedChanges: [.deleteRecord(CKRecord.ID(recordName: "bookmark-video@global:youtube", zoneID: zone.zoneID))]
+        )
+
+        #expect(changes.count == 2)
+        if case .saveRecord(let restoredID) = changes[0] {
+            #expect(restoredID == recordID)
+        } else {
+            Issue.record("Expected the pending save to survive refresh")
+        }
+        if case .deleteRecord = changes[1] {
+            // Expected: startup-buffered deletions survive too.
+        } else {
+            Issue.record("Expected the buffered deletion to survive refresh")
+        }
+    }
+
     @MainActor
     private static func makeMapper() -> CloudKitRecordMapper {
         CloudKitRecordMapper(zone: CKRecordZone(zoneName: RecordType.zoneName))


### PR DESCRIPTION
Fixes #978.

`Sync Now` rebuilds `CKSyncEngine` to fetch remote changes from a fresh cursor. Before rebuilding, it discarded locally queued record-zone changes, so an edit made shortly before Sync Now could be lost instead of uploaded.

Preserve both pending engine changes and changes buffered while the engine is unavailable, then transfer them to the rebuilt engine.

I could not run the test suite locally, so the changes and the added test should be checked carefully before merging.